### PR TITLE
Feat windows settings catalog v3 - Added more handling for macOS settings profiles

### DIFF
--- a/internal/resources/common/validators/settings_cataloge.go
+++ b/internal/resources/common/validators/settings_cataloge.go
@@ -1,0 +1,77 @@
+package validators
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// settingsCatalogValidator validates settings catalog json structure
+type settingsCatalogValidator struct{}
+
+// SettingsCatalogValidator returns a validator which ensures settings catalog json is valid
+func SettingsCatalogValidator() validator.String {
+	return &settingsCatalogValidator{}
+}
+
+// Description describes the validation in plain text formatting.
+func (v settingsCatalogValidator) Description(_ context.Context) string {
+	return "validates settings catalog configuration"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v settingsCatalogValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate performs the validation.
+func (v settingsCatalogValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Parse JSON
+	var settingsData struct {
+		SettingsDetails []struct {
+			SettingInstance struct {
+				ODataType          string `json:"@odata.type"`
+				SimpleSettingValue *struct {
+					ODataType  string `json:"@odata.type"`
+					ValueState string `json:"valueState,omitempty"`
+					Value      string `json:"value"`
+				} `json:"simpleSettingValue,omitempty"`
+			} `json:"settingInstance"`
+		} `json:"settingsDetails"`
+	}
+
+	if err := json.Unmarshal([]byte(req.ConfigValue.ValueString()), &settingsData); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Settings Catalog JSON",
+			fmt.Sprintf("Error parsing settings catalog JSON: %s", err),
+		)
+		return
+	}
+
+	// Validate each setting
+	for i, setting := range settingsData.SettingsDetails {
+		// Check for secret settings
+		if setting.SettingInstance.SimpleSettingValue != nil &&
+			setting.SettingInstance.SimpleSettingValue.ODataType == "#microsoft.graph.deviceManagementConfigurationSecretSettingValue" {
+
+			valueState := setting.SettingInstance.SimpleSettingValue.ValueState
+			expectedState := "notEncrypted"
+
+			if valueState != expectedState {
+				resp.Diagnostics.AddAttributeError(
+					req.Path,
+					"Invalid Secret Setting Value State",
+					fmt.Sprintf("Setting %d: For Secret Setting Value got '%s', expected '%s'. You must use 'notEncrypted' when trying to set a new secret value.",
+						i, valueState, expectedState),
+				)
+			}
+		}
+	}
+}

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go
@@ -237,6 +237,19 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 							Children []struct {
 								ODataType           string `json:"@odata.type"`
 								SettingDefinitionId string `json:"settingDefinitionId"`
+								SimpleSettingValue  *struct {
+									ODataType                     string                                                                     `json:"@odata.type"`
+									Value                         interface{}                                                                `json:"value"`
+									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+								} `json:"simpleSettingValue,omitempty"`
+								ChoiceSettingValue *struct {
+									Value    string `json:"value"`
+									Children []struct {
+										ODataType           string `json:"@odata.type"`
+										SettingDefinitionId string `json:"settingDefinitionId"`
+									} `json:"children"`
+									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+								} `json:"choiceSettingValue,omitempty"`
 							} `json:"children"`
 							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
 						} `json:"choiceSettingValue,omitempty"`
@@ -740,9 +753,44 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 
 							if child.ChoiceSettingValue != nil {
 								choiceValue := graphmodels.NewDeviceManagementConfigurationChoiceSettingValue()
-								choiceOdataType := "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue"
-								choiceValue.SetOdataType(&choiceOdataType)
 								choiceValue.SetValue(&child.ChoiceSettingValue.Value)
+
+								var choiceChildren []graphmodels.DeviceManagementConfigurationSettingInstanceable
+								for _, choiceChild := range child.ChoiceSettingValue.Children {
+									switch choiceChild.ODataType {
+									case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance":
+										nestedChoice := graphmodels.NewDeviceManagementConfigurationChoiceSettingInstance()
+										nestedChoice.SetOdataType(&choiceChild.ODataType)
+										nestedChoice.SetSettingDefinitionId(&choiceChild.SettingDefinitionId)
+
+										if choiceChild.ChoiceSettingValue != nil {
+											nestedChoiceValue := graphmodels.NewDeviceManagementConfigurationChoiceSettingValue()
+											nestedChoiceValue.SetValue(&choiceChild.ChoiceSettingValue.Value)
+											nestedChoiceValue.SetChildren([]graphmodels.DeviceManagementConfigurationSettingInstanceable{})
+											nestedChoice.SetChoiceSettingValue(nestedChoiceValue)
+										}
+										choiceChildren = append(choiceChildren, nestedChoice)
+
+									case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance":
+										simpleInstance := graphmodels.NewDeviceManagementConfigurationSimpleSettingInstance()
+										simpleInstance.SetOdataType(&choiceChild.ODataType)
+										simpleInstance.SetSettingDefinitionId(&choiceChild.SettingDefinitionId)
+
+										if choiceChild.SimpleSettingValue != nil {
+											switch choiceChild.SimpleSettingValue.ODataType {
+											case "#microsoft.graph.deviceManagementConfigurationStringSettingValue":
+												stringValue := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
+												stringValue.SetOdataType(&choiceChild.SimpleSettingValue.ODataType)
+												if strValue, ok := choiceChild.SimpleSettingValue.Value.(string); ok {
+													stringValue.SetValue(&strValue)
+												}
+												simpleInstance.SetSimpleSettingValue(stringValue)
+											}
+										}
+										choiceChildren = append(choiceChildren, simpleInstance)
+									}
+								}
+								choiceValue.SetChildren(choiceChildren)
 								choiceInstance.SetChoiceSettingValue(choiceValue)
 							}
 							children = append(children, choiceInstance)

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go
@@ -160,11 +160,19 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 						ODataType           string `json:"@odata.type"`
 						SettingDefinitionId string `json:"settingDefinitionId"`
 
+						// For nested simple settings within choice setting collection
 						SimpleSettingValue *struct {
 							ODataType                     string                                                                     `json:"@odata.type"`
 							Value                         interface{}                                                                `json:"value"`
 							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
 						} `json:"simpleSettingValue,omitempty"`
+
+						// For nested simple setting collection within choice setting collection
+						SimpleSettingCollectionValue []struct {
+							ODataType                     string                                                                     `json:"@odata.type"`
+							Value                         string                                                                     `json:"value"`
+							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+						} `json:"simpleSettingCollectionValue,omitempty"`
 
 						SettingInstanceTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingInstanceTemplateReference"`
 					} `json:"children"`
@@ -187,12 +195,31 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 								ODataType                        string                                                                     `json:"@odata.type"`
 								SettingDefinitionId              string                                                                     `json:"settingDefinitionId"`
 								SettingInstanceTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingInstanceTemplateReference"`
-								SimpleSettingValue               *struct {
+
+								// For nested simple settings within group setting collection within group setting collection
+								SimpleSettingValue *struct {
 									ODataType                     string                                                                     `json:"@odata.type"`
 									Value                         interface{}                                                                `json:"value"`
 									ValueState                    string                                                                     `json:"valueState,omitempty"`
 									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
 								} `json:"simpleSettingValue,omitempty"`
+
+								// For nested simple setting collections within group setting collection within group setting collection
+								SimpleSettingCollectionValue []struct {
+									ODataType                     string                                                                     `json:"@odata.type"`
+									Value                         string                                                                     `json:"value"`
+									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+								} `json:"simpleSettingCollectionValue,omitempty"`
+
+								// For nested choice settings within group setting collection within group setting collection
+								ChoiceSettingValue *struct {
+									Value    string `json:"value"`
+									Children []struct {
+										ODataType           string `json:"@odata.type"`
+										SettingDefinitionId string `json:"settingDefinitionId"`
+									} `json:"children"`
+									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+								} `json:"choiceSettingValue,omitempty"`
 							} `json:"children"`
 						} `json:"groupSettingCollectionValue,omitempty"`
 
@@ -213,6 +240,13 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 							} `json:"children"`
 							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
 						} `json:"choiceSettingValue,omitempty"`
+
+						// For nested simple setting collections within group setting collection
+						SimpleSettingCollectionValue []struct {
+							ODataType                     string                                                                     `json:"@odata.type"`
+							Value                         string                                                                     `json:"value"`
+							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+						} `json:"simpleSettingCollectionValue,omitempty"`
 
 						SettingInstanceTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingInstanceTemplateReference"`
 					} `json:"children"`
@@ -519,13 +553,11 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 			instance.SetOdataType(&detail.SettingInstance.ODataType)
 			instance.SetSettingDefinitionId(&detail.SettingInstance.SettingDefinitionId)
 
-			// Process group setting collection value
 			if len(detail.SettingInstance.GroupSettingCollectionValue) > 0 {
 				var groupValues []graphmodels.DeviceManagementConfigurationGroupSettingValueable
 
 				for _, groupItem := range detail.SettingInstance.GroupSettingCollectionValue {
 					groupValue := graphmodels.NewDeviceManagementConfigurationGroupSettingValue()
-					// Set the odata type for the group value
 					groupOdataType := "#microsoft.graph.deviceManagementConfigurationGroupSettingValue"
 					groupValue.SetOdataType(&groupOdataType)
 
@@ -536,6 +568,7 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 					var children []graphmodels.DeviceManagementConfigurationSettingInstanceable
 					for _, child := range groupItem.Children {
 						switch child.ODataType {
+
 						// For nested group setting collections within group setting collection
 						case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance":
 							nestedGroupInstance := graphmodels.NewDeviceManagementConfigurationGroupSettingCollectionInstance()
@@ -559,6 +592,7 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 
 											if nestedChild.SimpleSettingValue != nil {
 												switch nestedChild.SimpleSettingValue.ODataType {
+
 												case "#microsoft.graph.deviceManagementConfigurationStringSettingValue":
 													stringValue := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
 													stringValue.SetOdataType(&nestedChild.SimpleSettingValue.ODataType)
@@ -566,6 +600,15 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 														stringValue.SetValue(&strValue)
 													}
 													simpleInstance.SetSimpleSettingValue(stringValue)
+
+												case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue":
+													intValue := graphmodels.NewDeviceManagementConfigurationIntegerSettingValue()
+													intValue.SetOdataType(&nestedChild.SimpleSettingValue.ODataType)
+													if numValue, ok := nestedChild.SimpleSettingValue.Value.(float64); ok {
+														int32Value := int32(numValue)
+														intValue.SetValue(&int32Value)
+													}
+													simpleInstance.SetSimpleSettingValue(intValue)
 
 												case "#microsoft.graph.deviceManagementConfigurationSecretSettingValue":
 													secretValue := graphmodels.NewDeviceManagementConfigurationSecretSettingValue()
@@ -583,6 +626,41 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 												}
 											}
 											nestedChildren = append(nestedChildren, simpleInstance)
+
+										case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance":
+											simpleCollectionInstance := graphmodels.NewDeviceManagementConfigurationSimpleSettingCollectionInstance()
+											simpleCollectionInstance.SetOdataType(&nestedChild.ODataType)
+											simpleCollectionInstance.SetSettingDefinitionId(&nestedChild.SettingDefinitionId)
+
+											if len(nestedChild.SimpleSettingCollectionValue) > 0 {
+												var values []graphmodels.DeviceManagementConfigurationSimpleSettingValueable
+												for _, v := range nestedChild.SimpleSettingCollectionValue {
+													stringValue := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
+													stringValue.SetOdataType(&v.ODataType)
+													stringValue.SetValue(&v.Value)
+													values = append(values, stringValue)
+												}
+												simpleCollectionInstance.SetSimpleSettingCollectionValue(values)
+											}
+											nestedChildren = append(nestedChildren, simpleCollectionInstance)
+
+										case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance":
+											choiceInstance := graphmodels.NewDeviceManagementConfigurationChoiceSettingInstance()
+											choiceInstance.SetOdataType(&nestedChild.ODataType)
+											choiceInstance.SetSettingDefinitionId(&nestedChild.SettingDefinitionId)
+
+											if nestedChild.ChoiceSettingValue != nil {
+												choiceValue := graphmodels.NewDeviceManagementConfigurationChoiceSettingValue()
+												choiceOdataType := "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue"
+												choiceValue.SetOdataType(&choiceOdataType)
+												choiceValue.SetValue(&nestedChild.ChoiceSettingValue.Value)
+
+												// Always include empty children array for choice settings
+												choiceValue.SetChildren([]graphmodels.DeviceManagementConfigurationSettingInstanceable{})
+
+												choiceInstance.SetChoiceSettingValue(choiceValue)
+											}
+											nestedChildren = append(nestedChildren, choiceInstance)
 										}
 									}
 									nestedGroupValue.SetChildren(nestedChildren)
@@ -591,6 +669,26 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 								nestedGroupInstance.SetGroupSettingCollectionValue(nestedGroupValues)
 							}
 							children = append(children, nestedGroupInstance)
+
+							// For nested simple setting collections within group setting collection
+						case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance":
+							simpleCollectionInstance := graphmodels.NewDeviceManagementConfigurationSimpleSettingCollectionInstance()
+							simpleCollectionInstance.SetOdataType(&child.ODataType)
+							simpleCollectionInstance.SetSettingDefinitionId(&child.SettingDefinitionId)
+
+							// Handle simpleSettingCollectionValue
+							if len(child.SimpleSettingCollectionValue) > 0 {
+								var values []graphmodels.DeviceManagementConfigurationSimpleSettingValueable
+								for _, valueItem := range child.SimpleSettingCollectionValue {
+									stringValue := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
+									stringValue.SetOdataType(&valueItem.ODataType)
+									stringValue.SetValue(&valueItem.Value)
+									values = append(values, stringValue)
+								}
+								simpleCollectionInstance.SetSimpleSettingCollectionValue(values)
+							}
+
+							children = append(children, simpleCollectionInstance)
 
 							// For nested simple settings within group setting collection
 						case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance":

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go.backup
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go.backup
@@ -160,11 +160,19 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 						ODataType           string `json:"@odata.type"`
 						SettingDefinitionId string `json:"settingDefinitionId"`
 
+						// For nested simple settings within choice setting collection
 						SimpleSettingValue *struct {
 							ODataType                     string                                                                     `json:"@odata.type"`
 							Value                         interface{}                                                                `json:"value"`
 							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
 						} `json:"simpleSettingValue,omitempty"`
+
+						// For nested simple setting collection within choice setting collection
+						SimpleSettingCollectionValue []struct {
+							ODataType                     string                                                                     `json:"@odata.type"`
+							Value                         string                                                                     `json:"value"`
+							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+						} `json:"simpleSettingCollectionValue,omitempty"`
 
 						SettingInstanceTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingInstanceTemplateReference"`
 					} `json:"children"`
@@ -187,12 +195,31 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 								ODataType                        string                                                                     `json:"@odata.type"`
 								SettingDefinitionId              string                                                                     `json:"settingDefinitionId"`
 								SettingInstanceTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingInstanceTemplateReference"`
-								SimpleSettingValue               *struct {
+
+								// For nested simple settings within group setting collection within group setting collection
+								SimpleSettingValue *struct {
 									ODataType                     string                                                                     `json:"@odata.type"`
 									Value                         interface{}                                                                `json:"value"`
 									ValueState                    string                                                                     `json:"valueState,omitempty"`
 									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
 								} `json:"simpleSettingValue,omitempty"`
+
+								// For nested simple setting collections within group setting collection within group setting collection
+								SimpleSettingCollectionValue []struct {
+									ODataType                     string                                                                     `json:"@odata.type"`
+									Value                         string                                                                     `json:"value"`
+									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+								} `json:"simpleSettingCollectionValue,omitempty"`
+
+								// For nested choice settings within group setting collection within group setting collection
+								ChoiceSettingValue *struct {
+									Value    string `json:"value"`
+									Children []struct {
+										ODataType           string `json:"@odata.type"`
+										SettingDefinitionId string `json:"settingDefinitionId"`
+									} `json:"children"`
+									SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+								} `json:"choiceSettingValue,omitempty"`
 							} `json:"children"`
 						} `json:"groupSettingCollectionValue,omitempty"`
 
@@ -213,6 +240,13 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 							} `json:"children"`
 							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
 						} `json:"choiceSettingValue,omitempty"`
+
+						// For nested simple setting collections within group setting collection
+						SimpleSettingCollectionValue []struct {
+							ODataType                     string                                                                     `json:"@odata.type"`
+							Value                         string                                                                     `json:"value"`
+							SettingValueTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingValueTemplateReference"`
+						} `json:"simpleSettingCollectionValue,omitempty"`
 
 						SettingInstanceTemplateReference graphmodels.DeviceManagementConfigurationSettingValueTemplateReferenceable `json:"settingInstanceTemplateReference"`
 					} `json:"children"`
@@ -264,7 +298,6 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 				choiceValue := graphmodels.NewDeviceManagementConfigurationChoiceSettingValue()
 				choiceValue.SetValue(&detail.SettingInstance.ChoiceSettingValue.Value)
 
-				// Process each child within ChoiceSettingValue
 				var children []graphmodels.DeviceManagementConfigurationSettingInstanceable
 				for _, child := range detail.SettingInstance.ChoiceSettingValue.Children {
 					switch child.ODataType {
@@ -443,11 +476,8 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 			if detail.SettingInstance.SimpleSettingValue != nil {
 				switch detail.SettingInstance.SimpleSettingValue.ODataType {
 				case "#microsoft.graph.deviceManagementConfigurationStringSettingValue":
-					// Handle string value
 					value := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
 					value.SetOdataType(&detail.SettingInstance.SimpleSettingValue.ODataType)
-
-					// Type assertion for string
 					if stringValue, ok := detail.SettingInstance.SimpleSettingValue.Value.(string); ok {
 						value.SetValue(&stringValue)
 					} else {
@@ -458,13 +488,10 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 					instance.SetSimpleSettingValue(value)
 
 				case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue":
-					// Handle integer value
 					value := graphmodels.NewDeviceManagementConfigurationIntegerSettingValue()
 					value.SetOdataType(&detail.SettingInstance.SimpleSettingValue.ODataType)
-
-					// Type assertion for int
 					if intValue, ok := detail.SettingInstance.SimpleSettingValue.Value.(float64); ok {
-						intVal := int32(intValue) // Convert float64 to int
+						intVal := int32(intValue)
 						value.SetValue(&intVal)
 					} else {
 						tflog.Error(ctx, "Expected integer value but got different type", map[string]interface{}{
@@ -482,7 +509,6 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 			instance.SetOdataType(&detail.SettingInstance.ODataType)
 			instance.SetSettingDefinitionId(&detail.SettingInstance.SettingDefinitionId)
 
-			// Process each item in ChoiceSettingCollectionValue
 			if len(detail.SettingInstance.ChoiceSettingCollectionValue) > 0 {
 				var collectionValues []graphmodels.DeviceManagementConfigurationChoiceSettingValueable
 				for _, choiceItem := range detail.SettingInstance.ChoiceSettingCollectionValue {
@@ -527,13 +553,11 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 			instance.SetOdataType(&detail.SettingInstance.ODataType)
 			instance.SetSettingDefinitionId(&detail.SettingInstance.SettingDefinitionId)
 
-			// Process group setting collection value
 			if len(detail.SettingInstance.GroupSettingCollectionValue) > 0 {
 				var groupValues []graphmodels.DeviceManagementConfigurationGroupSettingValueable
 
 				for _, groupItem := range detail.SettingInstance.GroupSettingCollectionValue {
 					groupValue := graphmodels.NewDeviceManagementConfigurationGroupSettingValue()
-					// Set the odata type for the group value
 					groupOdataType := "#microsoft.graph.deviceManagementConfigurationGroupSettingValue"
 					groupValue.SetOdataType(&groupOdataType)
 
@@ -544,6 +568,7 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 					var children []graphmodels.DeviceManagementConfigurationSettingInstanceable
 					for _, child := range groupItem.Children {
 						switch child.ODataType {
+
 						// For nested group setting collections within group setting collection
 						case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance":
 							nestedGroupInstance := graphmodels.NewDeviceManagementConfigurationGroupSettingCollectionInstance()
@@ -567,6 +592,7 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 
 											if nestedChild.SimpleSettingValue != nil {
 												switch nestedChild.SimpleSettingValue.ODataType {
+
 												case "#microsoft.graph.deviceManagementConfigurationStringSettingValue":
 													stringValue := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
 													stringValue.SetOdataType(&nestedChild.SimpleSettingValue.ODataType)
@@ -574,6 +600,15 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 														stringValue.SetValue(&strValue)
 													}
 													simpleInstance.SetSimpleSettingValue(stringValue)
+
+												case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue":
+													intValue := graphmodels.NewDeviceManagementConfigurationIntegerSettingValue()
+													intValue.SetOdataType(&nestedChild.SimpleSettingValue.ODataType)
+													if numValue, ok := nestedChild.SimpleSettingValue.Value.(float64); ok {
+														int32Value := int32(numValue)
+														intValue.SetValue(&int32Value)
+													}
+													simpleInstance.SetSimpleSettingValue(intValue)
 
 												case "#microsoft.graph.deviceManagementConfigurationSecretSettingValue":
 													secretValue := graphmodels.NewDeviceManagementConfigurationSecretSettingValue()
@@ -591,6 +626,41 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 												}
 											}
 											nestedChildren = append(nestedChildren, simpleInstance)
+
+										case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance":
+											simpleCollectionInstance := graphmodels.NewDeviceManagementConfigurationSimpleSettingCollectionInstance()
+											simpleCollectionInstance.SetOdataType(&nestedChild.ODataType)
+											simpleCollectionInstance.SetSettingDefinitionId(&nestedChild.SettingDefinitionId)
+
+											if len(nestedChild.SimpleSettingCollectionValue) > 0 {
+												var values []graphmodels.DeviceManagementConfigurationSimpleSettingValueable
+												for _, v := range nestedChild.SimpleSettingCollectionValue {
+													stringValue := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
+													stringValue.SetOdataType(&v.ODataType)
+													stringValue.SetValue(&v.Value)
+													values = append(values, stringValue)
+												}
+												simpleCollectionInstance.SetSimpleSettingCollectionValue(values)
+											}
+											nestedChildren = append(nestedChildren, simpleCollectionInstance)
+
+										case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance":
+											choiceInstance := graphmodels.NewDeviceManagementConfigurationChoiceSettingInstance()
+											choiceInstance.SetOdataType(&nestedChild.ODataType)
+											choiceInstance.SetSettingDefinitionId(&nestedChild.SettingDefinitionId)
+
+											if nestedChild.ChoiceSettingValue != nil {
+												choiceValue := graphmodels.NewDeviceManagementConfigurationChoiceSettingValue()
+												choiceOdataType := "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue"
+												choiceValue.SetOdataType(&choiceOdataType)
+												choiceValue.SetValue(&nestedChild.ChoiceSettingValue.Value)
+
+												// Always include empty children array for choice settings
+												choiceValue.SetChildren([]graphmodels.DeviceManagementConfigurationSettingInstanceable{})
+
+												choiceInstance.SetChoiceSettingValue(choiceValue)
+											}
+											nestedChildren = append(nestedChildren, choiceInstance)
 										}
 									}
 									nestedGroupValue.SetChildren(nestedChildren)
@@ -599,6 +669,26 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 								nestedGroupInstance.SetGroupSettingCollectionValue(nestedGroupValues)
 							}
 							children = append(children, nestedGroupInstance)
+
+							// For nested simple setting collections within group setting collection
+						case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance":
+							simpleCollectionInstance := graphmodels.NewDeviceManagementConfigurationSimpleSettingCollectionInstance()
+							simpleCollectionInstance.SetOdataType(&child.ODataType)
+							simpleCollectionInstance.SetSettingDefinitionId(&child.SettingDefinitionId)
+
+							// Handle simpleSettingCollectionValue
+							if len(child.SimpleSettingCollectionValue) > 0 {
+								var values []graphmodels.DeviceManagementConfigurationSimpleSettingValueable
+								for _, valueItem := range child.SimpleSettingCollectionValue {
+									stringValue := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
+									stringValue.SetOdataType(&valueItem.ODataType)
+									stringValue.SetValue(&valueItem.Value)
+									values = append(values, stringValue)
+								}
+								simpleCollectionInstance.SetSimpleSettingCollectionValue(values)
+							}
+
+							children = append(children, simpleCollectionInstance)
 
 							// For nested simple settings within group setting collection
 						case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance":

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go.backup
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/construct_resource.go.backup
@@ -264,6 +264,7 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 				choiceValue := graphmodels.NewDeviceManagementConfigurationChoiceSettingValue()
 				choiceValue.SetValue(&detail.SettingInstance.ChoiceSettingValue.Value)
 
+				// Process each child within ChoiceSettingValue
 				var children []graphmodels.DeviceManagementConfigurationSettingInstanceable
 				for _, child := range detail.SettingInstance.ChoiceSettingValue.Children {
 					switch child.ODataType {
@@ -442,8 +443,11 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 			if detail.SettingInstance.SimpleSettingValue != nil {
 				switch detail.SettingInstance.SimpleSettingValue.ODataType {
 				case "#microsoft.graph.deviceManagementConfigurationStringSettingValue":
+					// Handle string value
 					value := graphmodels.NewDeviceManagementConfigurationStringSettingValue()
 					value.SetOdataType(&detail.SettingInstance.SimpleSettingValue.ODataType)
+
+					// Type assertion for string
 					if stringValue, ok := detail.SettingInstance.SimpleSettingValue.Value.(string); ok {
 						value.SetValue(&stringValue)
 					} else {
@@ -454,10 +458,13 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 					instance.SetSimpleSettingValue(value)
 
 				case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue":
+					// Handle integer value
 					value := graphmodels.NewDeviceManagementConfigurationIntegerSettingValue()
 					value.SetOdataType(&detail.SettingInstance.SimpleSettingValue.ODataType)
+
+					// Type assertion for int
 					if intValue, ok := detail.SettingInstance.SimpleSettingValue.Value.(float64); ok {
-						intVal := int32(intValue)
+						intVal := int32(intValue) // Convert float64 to int
 						value.SetValue(&intVal)
 					} else {
 						tflog.Error(ctx, "Expected integer value but got different type", map[string]interface{}{
@@ -475,6 +482,7 @@ func constructSettingsCatalogSettings(ctx context.Context, settingsJSON types.St
 			instance.SetOdataType(&detail.SettingInstance.ODataType)
 			instance.SetSettingDefinitionId(&detail.SettingInstance.SettingDefinitionId)
 
+			// Process each item in ChoiceSettingCollectionValue
 			if len(detail.SettingInstance.ChoiceSettingCollectionValue) > 0 {
 				var collectionValues []graphmodels.DeviceManagementConfigurationChoiceSettingValueable
 				for _, choiceItem := range detail.SettingInstance.ChoiceSettingCollectionValue {

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/map.md
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/map.md
@@ -1,3 +1,5 @@
+# Device Management Configuration Setting (Settings Catalog) Map of current type support and nesting.
+
 switch detail.SettingInstance.ODataType:
 ├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
 │   └── choiceSettingValue.children[] switch ODataType:
@@ -7,7 +9,7 @@ switch detail.SettingInstance.ODataType:
 │       │       └── case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue"
 │       ├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
 │       │   └── choiceSettingValue
-│       │       └── children[] switch ODataType: 
+│       │       └── children[] switch ODataType:
 │       │           ├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
 │       │           └── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance"
 │       ├── case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance"

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/map.md
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/map.md
@@ -1,0 +1,60 @@
+switch detail.SettingInstance.ODataType:
+├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
+│   └── choiceSettingValue.children[] switch ODataType:
+│       ├── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance"
+│       │   └── simpleSettingValue switch ODataType:
+│       │       ├── case "#microsoft.graph.deviceManagementConfigurationStringSettingValue"
+│       │       └── case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue"
+│       ├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
+│       │   └── choiceSettingValue
+│       │       └── children[] switch ODataType: 
+│       │           ├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
+│       │           └── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance"
+│       ├── case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance"
+│       │   └── groupSettingCollectionValue[]
+│       │       └── children if ODataType == "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance":
+│       │           └── simpleSettingValue switch ODataType:
+│       │               ├── case "#microsoft.graph.deviceManagementConfigurationStringSettingValue"
+│       │               └── case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue"
+│       └── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance"
+│           └── simpleSettingCollectionValue[]
+│               └── (@ODataType: "#microsoft.graph.deviceManagementConfigurationStringSettingValue")
+│
+├── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance"
+│   └── simpleSettingCollectionValue[]
+│       └── (@ODataType: "#microsoft.graph.deviceManagementConfigurationStringSettingValue")
+│
+├── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance"
+│   └── simpleSettingValue switch ODataType:
+│       ├── case "#microsoft.graph.deviceManagementConfigurationStringSettingValue"
+│       └──  case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue"
+│
+├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingCollectionInstance"
+│   └── choiceSettingCollectionValue[]
+│       └── children[].simpleSettingValue handle types:
+│           ├── string -> StringSettingValue
+│           └── float64 -> IntegerSettingValue
+│
+└── case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance"
+    └── groupSettingCollectionValue[]
+        └── children[] switch ODataType:
+            ├── case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance"
+            │   └── groupSettingCollectionValue[]
+            │       └── children[] switch ODataType:
+            │           ├── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance"
+            │           │   └── simpleSettingValue switch ODataType:
+            │           │       ├── case "#microsoft.graph.deviceManagementConfigurationStringSettingValue"
+            │           │       ├── case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue"
+            │           │       └── case "#microsoft.graph.deviceManagementConfigurationSecretSettingValue"
+            │           ├── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance"
+            │           └── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
+            │               └── choiceSettingValue
+            │                   └── children[] // Empty in code
+            ├── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance"
+            ├── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance"
+            │   └── simpleSettingValue switch ODataType:
+            │       ├── case "#microsoft.graph.deviceManagementConfigurationStringSettingValue"
+            │       ├── case "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue"
+            │       └── case "#microsoft.graph.deviceManagementConfigurationSecretSettingValue"
+            └── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
+                └── choiceSettingValue

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/map.md
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/map.md
@@ -38,6 +38,15 @@ switch detail.SettingInstance.ODataType:
 └── case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance"
     └── groupSettingCollectionValue[]
         └── children[] switch ODataType:
+            ├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
+            │   └── choiceSettingValue
+            │       └── children[] switch ODataType:
+            │           ├── case "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance"
+            │           │   └── choiceSettingValue
+            │           │       └── children[] // Empty in code
+            │           └── case "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance"
+            │               └── simpleSettingValue switch ODataType:
+            │                   └── case "#microsoft.graph.deviceManagementConfigurationStringSettingValue"
             ├── case "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance"
             │   └── groupSettingCollectionValue[]
             │       └── children[] switch ODataType:

--- a/internal/resources/device_and_app_management/beta/settings_catalog_v3/resource_base_v7.go
+++ b/internal/resources/device_and_app_management/beta/settings_catalog_v3/resource_base_v7.go
@@ -95,6 +95,7 @@ func (r *SettingsCatalogResource) Schema(ctx context.Context, req resource.Schem
 				MarkdownDescription: "Settings Catalog Policy settings defined as a valid JSON string, supporting up to 20 levels of nesting. Provide JSON-encoded settings structure.",
 				Validators: []validator.String{
 					customValidator.JSONSchemaValidator(),
+					//customValidator.SettingsCatalogValidator(),
 				},
 				PlanModifiers: []planmodifier.String{
 					planmodifiers.UseStateForUnknownString(),


### PR DESCRIPTION
# Change

Added additionally handing
Added map to keep track of what's configured. it's getting very complex. currently support 2 levels of nesting for groupSettingCollectionValue
Added handling for secret values
Bug fixes for settingcatalogbyid to support paginated GET
Started experimentation with settingcatalog json validator

## Type of Change


- [x] Refactor of existing code

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
