### PR TITLE
fix: correct resource naming for reusable policy settings to singular form

### DIFF
--- a/docs/resources/graph_beta_device_and_app_management_settings_catalog.md
+++ b/docs/resources/graph_beta_device_and_app_management_settings_catalog.md
@@ -21,7 +21,7 @@ resource "microsoft365_graph_beta_device_and_app_management_settings_catalog" "t
 
   settings = jsonencode({
 
-    "settingsDetails" : [
+    "settings" : [
       {
         "settingInstance" : {
           "groupSettingCollectionValue" : [
@@ -408,12 +408,12 @@ resource "microsoft365_graph_beta_device_and_app_management_settings_catalog" "t
 ### Required
 
 - `name` (String) Policy name
-- `settings` (String) Settings Catalog Policy settings defined as a valid JSON string. Provide JSON-encoded settings structure. This can either be extracted from an existing policy using the Intune gui export to JSON, via a script such as [this PowerShell script](https://github.com/deploymenttheory/terraform-provider-microsoft365/blob/main/scripts/GetSettingsCatalogConfigurationById.ps1) or created from scratch. The JSON structure should match the graph schema of the settings catalog. Please look at the terraform documentation for the settings catalog for examples and how to correctly format the HCL.
+- `settings` (String) Settings Catalog Policy settings defined as a valid JSON string. Provide JSON-encoded settings structure. This can either be extracted from an existing policy using the Intune gui `export JSON` functionality, via a script such as [this PowerShell script](https://github.com/deploymenttheory/terraform-provider-microsoft365/blob/main/scripts/ExportSettingsCatalogConfigurationById.ps1) or created from scratch. The JSON structure should match the graph schema of the settings catalog. Please look at the terraform documentation for the settings catalog for examples and how to correctly format the HCL.
 
 A correctly formatted field in the HCL should begin and end like this:
 ```hcl
 settings = jsonencode({
-  "settingsDetails": [
+  "settings": [
     {
         # ... settings configuration ...
     }

--- a/examples/microsoft365_graph_beta/microsoft365_graph_beta_device_and_app_management_reuseable_policy_setting/datasource.tf
+++ b/examples/microsoft365_graph_beta/microsoft365_graph_beta_device_and_app_management_reuseable_policy_setting/datasource.tf
@@ -1,6 +1,6 @@
 // Data Source: Reusable Policy Settings
 // Basic usage: lookup by display name
-data "microsoft365_graph_beta_device_and_app_management_reuseable_policy_settings" "example" {
+data "microsoft365_graph_beta_device_and_app_management_reuseable_policy_setting" "example" {
   display_name = "epm certificate"
 }
 

--- a/examples/microsoft365_graph_beta/microsoft365_graph_beta_device_and_app_management_reuseable_policy_setting/resource.tf
+++ b/examples/microsoft365_graph_beta/microsoft365_graph_beta_device_and_app_management_reuseable_policy_setting/resource.tf
@@ -1,6 +1,6 @@
 // Example: Reuseable Policy Setting Resource
 
-resource "microsoft365_graph_beta_device_and_app_management_reuseable_policy_settings" "example" {
+resource "microsoft365_graph_beta_device_and_app_management_reuseable_policy_setting" "example" {
   display_name = "epm certificate"
   description  = "Endpoint Privilege Management supports using reusable settings groups to manage the certificates in place of adding that certificate directly to an elevation rule"
   settings = jsonencode({

--- a/internal/datasources/device_and_app_management/graph_beta/reuseable_policy_settings/datasource.go
+++ b/internal/datasources/device_and_app_management/graph_beta/reuseable_policy_settings/datasource.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ResourceName = "graph_beta_device_and_app_management_reuseable_policy_settings"
+	ResourceName = "graph_beta_device_and_app_management_reuseable_policy_setting"
 )
 
 var (

--- a/internal/resources/device_and_app_management/graph_beta/reuseable_policy_settings/resource.go
+++ b/internal/resources/device_and_app_management/graph_beta/reuseable_policy_settings/resource.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ResourceName  = "graph_beta_device_and_app_management_reuseable_policy_settings"
+	ResourceName  = "graph_beta_device_and_app_management_reuseable_policy_setting"
 	CreateTimeout = 180
 	UpdateTimeout = 180
 	ReadTimeout   = 180


### PR DESCRIPTION
# Change


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
