### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tf-registry-goreleaser.yml
+++ b/.github/workflows/tf-registry-goreleaser.yml
@@ -2,6 +2,11 @@
 # for go build to complete successfully.
 name: Terraform Registry with goreleaser
 
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/10](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are needed:
- `contents: read` to allow the workflow to read repository contents.
- `packages: read` to allow the workflow to interact with GitHub Packages if necessary.
- `statuses: write` to update commit statuses if required by the `goreleaser` action.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
