### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/comment-failure.yml
+++ b/.github/workflows/comment-failure.yml
@@ -4,6 +4,9 @@ on:
   # This file is reused, and called from other workflows
   workflow_call:
 
+permissions:
+  issues: write
+
 jobs:
   comment-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/9](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/9)

To fix the issue, add a `permissions` block at the workflow level to explicitly define the required permissions. Since the workflow only needs to create a comment on an issue, the `issues: write` permission is sufficient. All other permissions should be omitted or set to `read` to minimize access.

The `permissions` block should be added at the root level of the workflow file, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
