### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ 'main' ]


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/8](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the workflow level (root of the YAML file) to explicitly define the least privileges required. Since this workflow only checks out code and runs tests, it only needs `contents: read` permissions. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
