### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/save-artifacts.yml
+++ b/.github/workflows/save-artifacts.yml
@@ -4,6 +4,9 @@ on:
   # This file is reused, and called from other workflows
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   save-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/5](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations:
- The `contents: read` permission is required to upload artifacts using the `actions/upload-artifact` action.
- No other permissions are necessary since the workflow does not perform any write operations or interact with other GitHub features.

The `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
