### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -3,6 +3,10 @@ name: Auto-Merge Dependabot
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-merge:
     name: '🤖 Auto-Merge Dependabot'


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/1](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
1. The `actions/checkout` step requires `contents: read` to fetch the repository code.
2. The `ahmadnassri/action-dependabot-auto-merge` step might require `pull-requests: write` to merge pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `auto-merge` job. In this case, adding it at the root level is sufficient and ensures consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
