### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,5 +1,8 @@
 name: PR Title Validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/4](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only reads the pull request title, the minimal required permission is `contents: read`. This permission should be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
