### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/metadata-maintainence.yml
+++ b/.github/workflows/metadata-maintainence.yml
@@ -1,5 +1,9 @@
 name: Extract Graph Metadata
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/3](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
1. The "Create Pull Request" step requires `contents: write` and `pull-requests: write` permissions.
2. Other steps do not appear to require additional permissions.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
