### PR TITLE
fix: graphBetaAutopatchGroups default scope_tags_ids set

### DIFF
--- a/internal/services/resources/device_management/graph_beta/autopatch_groups/resource.go
+++ b/internal/services/resources/device_management/graph_beta/autopatch_groups/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -295,11 +296,14 @@ func (r *AutopatchGroupsResource) Schema(ctx context.Context, req resource.Schem
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Set of scope tag IDs for this Autopatch group.",
-				PlanModifiers: []planmodifier.Set{
-					planmodifiers.DefaultSetValue(
-						[]attr.Value{types.StringValue("0")},
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("0"),
+						},
 					),
-				},
+				),
 			},
 			"timeouts": commonschema.Timeouts(ctx),
 		},


### PR DESCRIPTION
# Pull Request Description

## Summary

Fixed a bug with the default value for `scope_tag_ids` in [Windows Device Compliance Script](https://registry.terraform.io/providers/deploymenttheory/microsoft365/latest/docs/resources/graph_beta_device_management_windows_device_compliance_script) resources

### Issue Reference

N/A

### Motivation and Context

- Encountered a provider error when trying to import a [Windows Device Compliance Script](https://registry.terraform.io/providers/deploymenttheory/microsoft365/latest/docs/resources/graph_beta_device_management_windows_device_compliance_script) resource
- The error indicated a type mismatch for `scope_tag_ids` when relying on the default value
- This fix prevents the crash when no `scope_tag_ids` are set
```
╷
│ Error: failed to read schema for module.intune_compliance_policies.microsoft365_graph_beta_device_management_windows_device_compliance_script.example in registry.terraform.io/deploymenttheory/microsoft365: failed to retrieve schema from provider "registry.terraform.io/deploymenttheory/microsoft365": Request cancelled: The plugin6.(*GRPCProvider).GetProviderSchema request was cancelled.
│ 
│ 
╵


Stack trace from the terraform-provider-microsoft365_v0.27.6-alpha plugin:

panic: SetValueMust received error(s): Error | Invalid Set Element Type | While creating a Set value, an invalid element was detected. A Set must use the single, given element type. This is always an issue with the provider and should be reported to the provider developers.
	
	Set Element Type: basetypes.StringType
	Set Index (0) Element Type: basetypes.Int64Type

goroutine 47 [running]:
github.com/hashicorp/terraform-plugin-framework/types/basetypes.NewSetValueMust({0xc9b5d20?, 0x141e6e20?}, {0xc0000b3120?, 0x1?, 0x1?})
	github.com/hashicorp/terraform-plugin-framework@v1.15.1/types/basetypes/set_value.go:147 +0x3d4
github.com/hashicorp/terraform-plugin-framework/types.SetValueMust(...)
	github.com/hashicorp/terraform-plugin-framework@v1.15.1/types/set_value.go:49
github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/plan_modifiers.DefaultSetValue({0xc0000b3120, 0x1, 0x1})
	github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/plan_modifiers/set.go:82 +0x10e
github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/resources/device_management/graph_beta/autopatch_groups.(*AutopatchGroupsResource).Schema(0xc9b1218?, {0xc9b1218, 0xc0003ab200}, {}, 0xc00042ec60)
	github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/resources/device_management/graph_beta/autopatch_groups/resource.go:294 +0x217a
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ResourceSchemas(0xc0001fcc88, {0xc9b1218, 0xc0003ab200})
	github.com/hashicorp/terraform-plugin-framework@v1.15.1/internal/fwserver/server.go:679 +0x270
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).GetProviderSchema(0xc0001fcc88, {0xc9b1218, 0xc0003ab200}, 0xc00050f650?, 0xc0003ff5f0)
	github.com/hashicorp/terraform-plugin-framework@v1.15.1/internal/fwserver/server_getproviderschema.go:55 +0x236
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).GetProviderSchema(0xc0001fcc88, {0xc9b1218?, 0xc0003ab110?}, 0x141e6e20)
	github.com/hashicorp/terraform-plugin-framework@v1.15.1/internal/proto6server/server_getproviderschema.go:24 +0xb3
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).GetProviderSchema(0xc0002b7900, {0xc9b1218?, 0xc00016e480?}, 0xc00016e4b0)
	github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov6/tf6server/server.go:548 +0x14b
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_GetProviderSchema_Handler({0xbc92180, 0xc0002b7900}, {0xc9b1218, 0xc00016e480}, 0xc00054a000, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:507 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00026c600, {0xc9b1218, 0xc00016e3f0}, 0xc000534120, 0xc0003aa270, 0x141a0df8, 0x0)
	google.golang.org/grpc@v1.72.1/server.go:1405 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc00026c600, {0xc9b2460, 0xc0004b0000}, 0xc000534120)
	google.golang.org/grpc@v1.72.1/server.go:1815 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.72.1/server.go:1035 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 20
	google.golang.org/grpc@v1.72.1/server.go:1046 +0x11d

Error: The terraform-provider-microsoft365_v0.27.6-alpha plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.

``` 

### Dependencies

N/A

## Type of Change

Please mark the relevant option with an `x`:

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I have tested this code in the following browsers/environments: Azure Public Cloud

## Quality Checklist

- [X] I have reviewed my own code before requesting review
- [X] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [ ] My code follows the established style guidelines of this project
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings
- [X] I have performed a self-review of my own code
- [ ] My code is properly formatted according to project standards
