### PR TITLE
fix(windows_esp): correct validation logic

### DIFF
--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource.go
@@ -152,24 +152,24 @@ func (r *WindowsEnrollmentStatusPageResource) Schema(ctx context.Context, req re
 				Required:            true,
 			},
 			"allow_device_reset_on_install_failure": schema.BoolAttribute{
-				MarkdownDescription: "Allow or block device reset on installation failure. Can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false.",
+				MarkdownDescription: "Allow or block device reset on installation failure. When block_device_use_until_all_apps_and_profiles_are_installed is true, this must be false. When block_device_use_until_all_apps_and_profiles_are_installed is false, this can be true or false.",
 				Required:            true,
 				Validators: []validator.Bool{
-					validators.BoolCanOnlyBeTrueWhen(
+					validators.BoolCanOnlyBeFalseWhen(
 						"block_device_use_until_all_apps_and_profiles_are_installed",
-						false,
-						"allow_device_reset_on_install_failure can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false",
+						true,
+						"allow_device_reset_on_install_failure must be false when block_device_use_until_all_apps_and_profiles_are_installed is true",
 					),
 				},
 			},
 			"allow_device_use_on_install_failure": schema.BoolAttribute{
-				MarkdownDescription: "Allow the user to continue using the device on installation failure. Can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false.",
+				MarkdownDescription: "Allow the user to continue using the device on installation failure. When block_device_use_until_all_apps_and_profiles_are_installed is true, this must be false. When block_device_use_until_all_apps_and_profiles_are_installed is false, this can be true or false.",
 				Required:            true,
 				Validators: []validator.Bool{
-					validators.BoolCanOnlyBeTrueWhen(
+					validators.BoolCanOnlyBeFalseWhen(
 						"block_device_use_until_all_apps_and_profiles_are_installed",
-						false,
-						"allow_device_use_on_install_failure can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false",
+						true,
+						"allow_device_use_on_install_failure must be false when block_device_use_until_all_apps_and_profiles_are_installed is true",
 					),
 				},
 			},
@@ -193,13 +193,13 @@ func (r *WindowsEnrollmentStatusPageResource) Schema(ctx context.Context, req re
 				},
 			},
 			"only_fail_selected_blocking_apps_in_technician_phase": schema.BoolAttribute{
-				MarkdownDescription: "When this is true, only the selected blocking apps will be failed in the technician phase.",
+				MarkdownDescription: "When true, only the selected blocking apps will be failed in the technician phase. When block_device_use_until_all_apps_and_profiles_are_installed is true, this must be false. When block_device_use_until_all_apps_and_profiles_are_installed is false, this can be true or false.",
 				Required:            true,
 				Validators: []validator.Bool{
-					validators.BoolCanOnlyBeTrueWhen(
+					validators.BoolCanOnlyBeFalseWhen(
 						"block_device_use_until_all_apps_and_profiles_are_installed",
-						false,
-						"allow_device_use_on_install_failure can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false",
+						true,
+						"only_fail_selected_blocking_apps_in_technician_phase must be false when block_device_use_until_all_apps_and_profiles_are_installed is true",
 					),
 				},
 			},


### PR DESCRIPTION
# Pull Request Description

## Summary

The validation logic for allow_device_reset_on_install_failure, allow_device_use_on_install_failure, and only_fail_selected_blocking_apps_in_technician_phase is inverted, causing valid configurations to be rejected during terraform plan. 

### Issue Reference

Fixes #853

### Motivation and Context

**Why is this change needed?**  
To support importing and managing existing Intune Enrollment Status Page configurations that are currently deployed in production. The validation logic was inverted, incorrectly rejecting valid ESP configurations where escape hatch options are set to `false`, preventing users from running `terraform plan` or importing existing policies.

### Dependencies

- List any dependencies that are required for this change
- Include any configuration changes needed
- Note any version updates required

## Type of Change

Please mark the relevant option with an `x`:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist

- [ ] I have reviewed my own code before requesting review
- [ ] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [ ] My code follows the established style guidelines of this project
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
- [ ] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

<img width="300" height="127" alt="image" src="https://github.com/user-attachments/assets/339ac3e8-fe98-4a96-b732-71700ccc88f0" />

## Additional Notes

[Add any additional information that might be helpful for reviewers]
