### PR TITLE
fix(autopilot): preserve hybrid_azure_ad_join_skip_connectivity_check for azure ad joined profiles

### DIFF
--- a/internal/services/resources/device_management/graph_beta/windows_autopilot_deployment_profile/tests/responses/validate_create/post_windows_autopilot_deployment_profile_04_hololens.json
+++ b/internal/services/resources/device_management/graph_beta/windows_autopilot_deployment_profile/tests/responses/validate_create/post_windows_autopilot_deployment_profile_04_hololens.json
@@ -12,7 +12,6 @@
   "roleScopeTagIds": ["0"],
   "deviceType": "holoLens",
   "deviceJoinType": "azureADJoined",
-  "hybridAzureADJoinSkipConnectivityCheck": false,
   "outOfBoxExperienceSetting": {
     "privacySettingsHidden": true,
     "eulaHidden": true,

--- a/internal/services/resources/device_management/graph_beta/windows_autopilot_deployment_profile/tests/responses/validate_create/post_windows_autopilot_deployment_profile_success.json
+++ b/internal/services/resources/device_management/graph_beta/windows_autopilot_deployment_profile/tests/responses/validate_create/post_windows_autopilot_deployment_profile_success.json
@@ -12,7 +12,6 @@
   "roleScopeTagIds": ["0", "1"],
   "deviceType": "windowsPc",
   "deviceJoinType": "azureADJoined",
-  "hybridAzureADJoinSkipConnectivityCheck": false,
   "outOfBoxExperienceSetting": {
     "privacySettingsHidden": true,
     "eulaHidden": true,


### PR DESCRIPTION
## Summary

Fixes the "Provider produced inconsistent result after apply" error for `microsoft365_graph_beta_device_management_windows_autopilot_deployment_profile` resource when using Azure AD joined profiles. The `hybrid_azure_ad_join_skip_connectivity_check` field was incorrectly becoming `null` after apply instead of maintaining its configured `false` value.

### Issue Reference

Fixes issue where Terraform reported: `.hybrid_azure_ad_join_skip_connectivity_check: was cty.False, but now null`

### Motivation and Context

- **Problem**: When creating/updating an Autopilot deployment profile with `device_join_type = "microsoft_entra_joined"` and `hybrid_azure_ad_join_skip_connectivity_check = false`, Terraform would report an inconsistency error after apply
- **Root Cause**: According to Microsoft Graph API documentation, the `hybridAzureADJoinSkipConnectivityCheck` property only exists on `activeDirectoryWindowsAutopilotDeploymentProfile` (Hybrid AD joined). It does NOT exist on `azureADWindowsAutopilotDeploymentProfile` (Azure AD joined). The state mapping was not preserving the configured value when the API didn't return the field.
- **Solution**: Updated state mapping to preserve the configured value for Azure AD joined profiles since the API doesn't return this field, while continuing to read it from the API for Hybrid AD joined profiles

### Dependencies

None

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this code in the following browsers/environments: Provider builds successfully, test mocks updated to match Microsoft Graph API behavior

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

[Add screenshots or recordings that demonstrate the changes]

## Additional Notes

### Changes Made

1. **Updated `state.go`**: Modified `MapRemoteResourceStateToTerraform()` to properly handle the `hybrid_azure_ad_join_skip_connectivity_check` field:
   - For Hybrid AD joined profiles: Reads value from API using `GetHybridAzureADJoinSkipConnectivityCheck()`
   - For Azure AD joined profiles: Preserves configured value from state (defaults to `false` if null/unknown)

2. **Corrected Test Mocks**: Updated test mock JSON files to match actual Microsoft Graph API behavior:
   - Removed `hybridAzureADJoinSkipConnectivityCheck` from `post_windows_autopilot_deployment_profile_success.json` (Azure AD joined)
   - Removed `hybridAzureADJoinSkipConnectivityCheck` from `post_windows_autopilot_deployment_profile_04_hololens.json` (Azure AD joined)
   - Kept `hybridAzureADJoinSkipConnectivityCheck` in `post_windows_autopilot_deployment_profile_02_hybrid.json` (Hybrid AD joined)

### API Documentation Reference

- [azureADWindowsAutopilotDeploymentProfile](https://learn.microsoft.com/en-us/graph/api/resources/intune-enrollment-azureadwindowsautopilotdeploymentprofile?view=graph-rest-beta) - Does NOT include `hybridAzureADJoinSkipConnectivityCheck` property
- [activeDirectoryWindowsAutopilotDeploymentProfile](https://learn.microsoft.com/en-us/graph/api/resources/intune-enrollment-activedirectorywindowsautopilotdeploymentprofile?view=graph-rest-beta) - DOES include `hybridAzureADJoinSkipConnectivityCheck` property
