### PR TITLE
fix: remove global_secure_access attribute in applications of conditional access policy

### DIFF
--- a/docs/resources/graph_beta_identity_and_access_conditional_access_policy.md
+++ b/docs/resources/graph_beta_identity_and_access_conditional_access_policy.md
@@ -2705,7 +2705,6 @@ Required:
 Optional:
 
 - `application_filter` (Attributes) Configure app filters you want to policy to apply to. Using custom security attributes you can use the rule builder or rule syntax text box to create or edit the filter rules. this feature is currently in preview, only attributes of type String are supported. Attributes of type Integer or Boolean are not currently supported. Learn more here 'https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-filter-for-applications'. (see [below for nested schema](#nestedatt--conditions--applications--application_filter))
-- `global_secure_access` (Attributes) Global Secure Access settings for the conditional access policy. (see [below for nested schema](#nestedatt--conditions--applications--global_secure_access))
 
 <a id="nestedatt--conditions--applications--application_filter"></a>
 ### Nested Schema for `conditions.applications.application_filter`
@@ -2714,12 +2713,6 @@ Required:
 
 - `mode` (String) Mode of the filter. Possible values are: include, exclude.
 - `rule` (String) Rule syntax for the filter.
-
-
-<a id="nestedatt--conditions--applications--global_secure_access"></a>
-### Nested Schema for `conditions.applications.global_secure_access`
-
-
 
 <a id="nestedatt--conditions--users"></a>
 ### Nested Schema for `conditions.users`

--- a/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/construct.go
+++ b/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/construct.go
@@ -164,15 +164,6 @@ func constructConditions(ctx context.Context, data *ConditionalAccessConditions)
 			}
 		}
 
-		// Handle global_secure_access (typically null)
-		if !data.Applications.GlobalSecureAccess.IsNull() && !data.Applications.GlobalSecureAccess.IsUnknown() {
-			// For now, since this field is typically null in API examples,
-			// we'll set it to null. Future implementation can expand this as needed.
-			applications["globalSecureAccess"] = nil
-		} else {
-			applications["globalSecureAccess"] = nil
-		}
-
 		if len(applications) > 0 {
 			conditions["applications"] = applications
 		}

--- a/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/model.go
+++ b/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/model.go
@@ -46,7 +46,6 @@ type ConditionalAccessApplications struct {
 	IncludeUserActions                          types.Set                `tfsdk:"include_user_actions"`
 	IncludeAuthenticationContextClassReferences types.Set                `tfsdk:"include_authentication_context_class_references"`
 	ApplicationFilter                           *ConditionalAccessFilter `tfsdk:"application_filter"`
-	GlobalSecureAccess                          types.Object             `tfsdk:"global_secure_access"`
 }
 
 // ConditionalAccessUsers represents the users condition

--- a/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/resource.go
+++ b/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/resource.go
@@ -257,15 +257,6 @@ func (r *ConditionalAccessPolicyResource) Schema(ctx context.Context, req resour
 									},
 								},
 							},
-							"global_secure_access": schema.SingleNestedAttribute{
-								MarkdownDescription: "Global Secure Access settings for the conditional access policy.",
-								Optional:            true,
-								Computed:            true,
-								Attributes:          map[string]schema.Attribute{
-									// Note: This field appears in API responses but is typically null
-									// Adding minimal structure based on API observations
-								},
-							},
 						},
 					},
 					"users": schema.SingleNestedAttribute{

--- a/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/state.go
+++ b/internal/services/resources/identity_and_access/graph_beta/conditional_access_policy/state.go
@@ -301,16 +301,6 @@ func mapApplications(ctx context.Context, applicationsRaw any) *ConditionalAcces
 		result.ApplicationFilter = nil
 	}
 
-	// Map globalSecureAccess (typically null)
-	if globalSecureAccessRaw, ok := applications["globalSecureAccess"]; ok && globalSecureAccessRaw != nil {
-		tflog.Debug(ctx, "Mapping globalSecureAccess", map[string]any{"globalSecureAccess": globalSecureAccessRaw})
-		// For now, since this field is typically null, we'll map it as null object
-		result.GlobalSecureAccess = types.ObjectNull(map[string]attr.Type{})
-	} else {
-		tflog.Debug(ctx, "globalSecureAccess not found or is null")
-		result.GlobalSecureAccess = types.ObjectNull(map[string]attr.Type{})
-	}
-
 	return result
 }
 


### PR DESCRIPTION
# Pull Request Description

## Summary

Since `global_secure_access` attribute for Conditional Access applications does not exist, it has been removed.

### Issue Reference

n/a

### Motivation and Context

The Global Secure Access checkbox of the screenshot is an alias for inserting the following applications:

```json
"includeApplications": [
  "c08f52c9-8f03-4558-a0ea-9a4c878cf343",
  "5dc48733-b5df-475c-a49b-fa307ef00853"
]
```

* The `c08f52c9-8f03-4558-a0ea-9a4c878cf343` app is "Microsoft apps with Global Secure Access".
* The `5dc48733-b5df-475c-a49b-fa307ef00853` app is "Internet resources with Global Secure Access".

### Dependencies

n/a

## Type of Change

Please mark the relevant option with an `x`:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [ ] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

<img width="2478" height="1860" alt="" src="https://github.com/user-attachments/assets/f58348c5-825c-45a0-85a1-edf7b49fb884" />

## Additional Notes

```json
{
    "@odata.context": "https://graph.microsoft.com/beta/$metadata#identity/conditionalAccess/policies/$entity",
    "@microsoft.graph.tips": "Use $select to choose only the properties your app needs, as this can lead to performance improvements. For example: GET identity/conditionalAccess/policies('<guid>')?$select=conditions,createdDateTime",
    "id": "35be09cf-76ce-45de-a88f-bfce19bd2615",
    "templateId": null,
    "displayName": "sample policy",
    "createdDateTime": "2025-10-31T06:01:13.2632732Z",
    "modifiedDateTime": "2025-11-19T03:24:09.0078345Z",
    "state": "enabled",
    "deletedDateTime": null,
    "grantControls": null,
    "partialEnablementStrategy": null,
    "conditions": {
        "userRiskLevels": [],
        "signInRiskLevels": [],
        "clientAppTypes": [
            "all"
        ],
        "platforms": null,
        "locations": null,
        "times": null,
        "deviceStates": null,
        "devices": null,
        "clientApplications": null,
        "applications": {
            "includeApplications": [
                "c08f52c9-8f03-4558-a0ea-9a4c878cf343",
                "5dc48733-b5df-475c-a49b-fa307ef00853"
            ],
            "excludeApplications": [],
            "includeUserActions": [],
            "includeAuthenticationContextClassReferences": [],
            "applicationFilter": null
        },
        "users": {
            "includeUsers": [
                "All"
            ],
            "excludeUsers": [],
            "includeGroups": [],
            "excludeGroups": [],
            "includeRoles": [],
            "excludeRoles": [],
            "includeGuestsOrExternalUsers": null,
            "excludeGuestsOrExternalUsers": null
        }
    },
    "sessionControls": {
        "disableResilienceDefaults": null,
        "applicationEnforcedRestrictions": null,
        "cloudAppSecurity": null,
        "signInFrequency": null,
        "persistentBrowser": null,
        "continuousAccessEvaluation": null,
        "secureSignInSession": null,
        "networkAccessSecurity": {
            "policyId": "e493ebd0-ff9a-4f05-976b-7ab86f0cf856",
            "isEnabled": true
        },
        "globalSecureAccessFilteringProfile": {
            "profileId": "e493ebd0-ff9a-4f05-976b-7ab86f0cf856",
            "isEnabled": true
        }
    }
}
```