### PR TITLE
fix: Add a runRemediationScript attribute of microsoft365_graph_beta_device_management_windows_remediation_script resource assignment

### DIFF
--- a/internal/services/resources/device_management/graph_beta/windows_remediation_script/construct_assignment.go
+++ b/internal/services/resources/device_management/graph_beta/windows_remediation_script/construct_assignment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/helpers"
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/constructors"
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -61,6 +62,11 @@ func constructAssignment(ctx context.Context, data *DeviceHealthScriptResourceMo
 		if runSchedule != nil {
 			graphAssignment.SetRunSchedule(runSchedule)
 		}
+
+		// Intune Admin Center always sets runRemediationScript as `true` when creating assignments via Graph API Beta.
+		// To remain consistent with the service and ensure remediation runs as expected we force this to true when constructing the assignment request.
+		// The Graph API currently returns `false` for this attribute in responses even when it was sent as `true` on creation.
+		graphAssignment.SetRunRemediationScript(helpers.BoolPtr(true))
 
 		scriptAssignments = append(scriptAssignments, graphAssignment)
 	}


### PR DESCRIPTION
## Summary

Add a runRemediationScript attribute of `microsoft365_graph_beta_device_management_windows_remediation_script` resource.

### Issue Reference

n/a

### Motivation and Context

https://learn.microsoft.com/en-us/graph/api/intune-devices-devicehealthscriptassignment-update?view=graph-rest-beta#request-body says to support `runRemediationScript` attribute. 
In Intune Admin Center, this is always set to true, while the API response always returns false.

Therefore, we have modified this provider to align its behavior with that of Intune Admin Center.

### Dependencies

* n/a

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [ ] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

n/a

## Additional Notes

n/a
