### PR TITLE
Potential fix for code scanning alert no. 25: Clear-text storage of sensitive information

### DIFF
--- a/scripts/pipeline/bi_weekly_tests/map_credentials.py
+++ b/scripts/pipeline/bi_weekly_tests/map_credentials.py
@@ -132,8 +132,12 @@ def map_credentials(service: str) -> None:
     github_env = os.environ.get("GITHUB_ENV")
     if github_env:
         export_to_github_env("M365_CLIENT_ID", client_id)
-        export_to_github_env("M365_CLIENT_SECRET", client_secret)
+        # Do not export client secret to GITHUB_ENV to avoid writing it in clear text
         export_to_github_env("SKIP_TESTS", "false")
+
+    # Set credentials in the in-memory environment for use by subsequent processes
+    os.environ["M365_CLIENT_ID"] = client_id
+    os.environ["M365_CLIENT_SECRET"] = client_secret
 
     print(f"✅ Credentials configured for {service}")
 


### PR DESCRIPTION
Potential fix for [https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/25](https://github.com/deploymenttheory/terraform-provider-microsoft365/security/code-scanning/25)

General approach: avoid writing the secret value itself to persistent storage. Instead, either (a) do not export the secret at all (prefer using the original environment variables directly), or (b) if the test runner requires `M365_CLIENT_SECRET`, store a reference or masked form rather than the actual secret. Since we must preserve functionality (tests still need the real secret), the best we can do within this script is to avoid writing the secret into the environment file and rely on it being already present in the job’s environment.

Best specific fix here:

- Continue exporting non-sensitive values (like `M365_CLIENT_ID`, `SKIP_TESTS`) via `GITHUB_ENV`.
- Stop writing `M365_CLIENT_SECRET` into `GITHUB_ENV`.
- Instead, set `M365_CLIENT_SECRET` only in the current process environment (which is already in-memory and based on the original secret), so child processes spawned by this script (e.g., the test runner) can see it, but it is not written to disk.
- This preserves behavior for a common case where tests are invoked from within this process (or its children), while removing the clear-text storage in `GITHUB_ENV`.

Concretely:

- In `map_credentials`, remove the call `export_to_github_env("M365_CLIENT_SECRET", client_secret)`.
- After exporting `M365_CLIENT_ID`, add assignments:
  - `os.environ["M365_CLIENT_ID"] = client_id`
  - `os.environ["M365_CLIENT_SECRET"] = client_secret`
- Leave `export_to_github_env("M365_CLIENT_ID", ...)` and `export_to_github_env("SKIP_TESTS", ...)` intact.

No new imports or helper methods are needed; we already import `os`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
