### PR TITLE
chore(w365): fix terraform import for microsoftmanageddesktop profile with null value

### DIFF
--- a/internal/services/resources/windows_365/graph_beta/cloud_pc_provisioning_policy/resource.go
+++ b/internal/services/resources/windows_365/graph_beta/cloud_pc_provisioning_policy/resource.go
@@ -327,9 +327,10 @@ func (r *CloudPcProvisioningPolicyResource) Schema(ctx context.Context, req reso
 					"profile": schema.StringAttribute{
 						Optional: true,
 						Computed: true,
-						Default:  stringdefault.StaticString("4aa9b805-9494-4eed-a04b-ed51ec9e631e"),
-						MarkdownDescription: "The name of the Microsoft Managed Desktop profile that the Windows 365 Cloud PC is associated with." +
-							"'4aa9b805-9494-4eed-a04b-ed51ec9e631e' is the default Autopatch Group ID. Via 'https://mmdls.microsoft.com/device/v1/windows365/autopatchGroups'",
+						PlanModifiers: []planmodifier.String{
+							planmodifiers.UseStateForUnknownString(),
+						},
+						MarkdownDescription: "The name of the Microsoft Managed Desktop profile that the Windows 365 Cloud PC is associated with.",
 					},
 				},
 			},


### PR DESCRIPTION
# Pull Request Description

## Summary

Fix perpetual drift on `microsoft_managed_desktop.profile` field in Cloud PC provisioning policy resource after import by removing incorrect default value that doesn't match Graph API behavior.

### Issue Reference

https://github.com/deploymenttheory/terraform-provider-microsoft365/issues/2382

### Previous PR

https://github.com/deploymenttheory/terraform-provider-microsoft365/pull/567

### Motivation and Context

- **Why is this change needed?** After importing a Windows 365 Cloud PC provisioning policy, `terraform plan` shows perpetual drift on the `microsoft_managed_desktop.profile` field, even when no changes have been made.
- **What problem does it solve?** The schema had `Default: stringdefault.StaticString("4aa9b805-9494-4eed-a04b-ed51ec9e631e")` but the Graph API returns `null` for this field. This mismatch caused Terraform to show changes on every plan:
  ```
  ~ profile = null -> "4aa9b805-9494-4eed-a04b-ed51ec9e631e"
  ```
- **Evidence:** Verified via direct Graph API call that all provisioning policies return `"profile": null`:
  ```json
  "microsoftManagedDesktop": {
    "managedType": "starterManaged",
    "profile": null
  }
  ```

### Dependencies

- None - this is a schema-only change with no external dependencies

## Type of Change

Please mark the relevant option with an `x`:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Wiki/README/Code comments)
- [ ] Refactor (code improvement without functional changes)
- [ ] Style update (formatting, renaming)
- [ ] Configuration change
- [ ] Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this code in the following browsers/environments: Windows 11, Graph API Beta endpoint

### Manual Verification Steps
1. Verified Graph API returns `profile: null` via `az rest` command
2. Confirmed Microsoft Graph documentation lists `profile` as a valid field on `microsoftManagedDesktop` resource type
3. Verified package compiles: `go build ./internal/services/resources/windows_365/graph_beta/cloud_pc_provisioning_policy/...`

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

**Before (perpetual drift):**
```hcl
~ microsoft_managed_desktop {
    ~ profile = null -> "4aa9b805-9494-4eed-a04b-ed51ec9e631e"
  }
```

**After (no drift):**
```
No changes. Your infrastructure matches the configuration.
```

## Additional Notes

### Changes Made

**File:** `internal/services/resources/windows_365/graph_beta/cloud_pc_provisioning_policy/resource.go`

```go
// Before
"profile": schema.StringAttribute{
    Optional: true,
    Computed: true,
    Default:  stringdefault.StaticString("4aa9b805-9494-4eed-a04b-ed51ec9e631e"),
    MarkdownDescription: "...'4aa9b805-9494-4eed-a04b-ed51ec9e631e' is the default Autopatch Group ID...",
},

// After
"profile": schema.StringAttribute{
    Optional: true,
    Computed: true,
    PlanModifiers: []planmodifier.String{
        planmodifiers.UseStateForUnknownString(),
    },
    MarkdownDescription: "The name of the Microsoft Managed Desktop profile that the Windows 365 Cloud PC is associated with.",
},
```

### Why This Fix Works

1. **Removed `Default`**: The API returns `null`, so having a default value causes state mismatch
2. **Added `UseStateForUnknownString()`**: Preserves the API-returned value in state during planning, preventing Terraform from trying to recompute it

### References

- [Microsoft Graph API - microsoftManagedDesktop resource](https://learn.microsoft.com/en-us/graph/api/resources/microsoftmanageddesktop?view=graph-rest-beta)
- [Terraform Plan Modifiers - UseStateForUnknown](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#useStateforunknown)
