### PR TITLE
fix: Use PUT instead of PATCH for windows_autopilot_device_preparation_policy updates to handle settings navigation property

### DIFF
--- a/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/crud.go
+++ b/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/crud.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/crud"
+	customrequest "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/custom_requests"
 	errors "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/errors/kiota"
 	sharedmodels "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/shared_models/graph_beta"
 )
@@ -305,12 +306,22 @@ func (r *WindowsAutopilotDevicePreparationPolicyResource) Update(
 		return
 	}
 
-	_, err = r.client.
-		DeviceManagement().
-		ConfigurationPolicies().
-		ByDeviceManagementConfigurationPolicyId(state.ID.ValueString()).
-		Patch(ctx, requestBody, nil)
-	if err != nil {
+	// Use PUT instead of PATCH because the Graph API does not allow PATCH on
+	// the 'settings' navigation property of deviceManagementConfigurationPolicy.
+	// The Intune admin center also uses PUT for this endpoint, as confirmed by
+	// inspecting its Graph API calls via browser DevTools.
+	putRequest := customrequest.PutRequestConfig{
+		APIVersion:  customrequest.GraphAPIBeta,
+		Endpoint:    r.ResourcePath,
+		ResourceID:  state.ID.ValueString(),
+		RequestBody: requestBody,
+	}
+
+	if err := customrequest.PutRequestByResourceId(
+		ctx,
+		r.client.GetAdapter(),
+		putRequest,
+	); err != nil {
 		errors.HandleKiotaGraphError(
 			ctx,
 			err,


### PR DESCRIPTION
# Pull Request Description

## Summary

Fix update operation for `windows_autopilot_device_preparation_policy` resource by replacing PATCH with PUT to properly handle the `settings` navigation property.

### Issue Reference

Fixes #2488 

### Motivation and Context

- The Update operation fails with a `400 Bad Request` error when modifying any attribute of the `microsoft365_graph_beta_device_management_windows_autopilot_device_preparation_policy` resource
- The Microsoft Graph API does not allow PATCH requests on navigation properties like `settings` for the `deviceManagementConfigurationPolicy` entity type
- Error message: "Cannot apply PATCH to navigation property 'settings' on entity type 'microsoft.management.services.api.deviceManagementConfigurationPolicy'"
- This issue prevents users from updating any Windows Autopilot Device Preparation Policy after initial creation

### Dependencies

- Uses existing `customrequest.PutRequestByResourceId` utility function
- No new dependencies or version updates required
- No configuration changes needed

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have verified the fix resolves the 400 error on update operations
- [x] I have confirmed the code compiles successfully
- [x] I have verified that Intune admin center uses PUT for this same endpoint by inspecting Graph API calls via browser DevTools
- [x] The change follows the same pattern used by other configuration policy resources in this codebase (e.g., `settings_catalog_configuration_policy`)
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following environments: Azure/Microsoft 365 environment with Windows Autopilot Device Preparation Policies

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (code comments explaining the change)
- [x] I have commented my code, particularly in complex areas
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards
- [ ] All CI/CD pipelines pass without errors or warnings

## Additional Notes

### Context

- This issue is related to a known Graph API limitation documented in [microsoftgraph/powershell-intune-samples#286](https://github.com/microsoftgraph/powershell-intune-samples/issues/286)
- The Microsoft Graph API [documentation for updating deviceManagementConfigurationPolicy](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/beta/api/intune-deviceconfigv2-devicemanagementconfigurationpolicy-update.md) supports PATCH on the base resource, but `settings` is a navigation property that cannot be included in PATCH operations
- The Create operation works correctly because POST accepts navigation properties inline
- Intune admin center successfully updates these policies using PUT with the full resource body including settings

### Verification from Intune Admin Center

The following screenshot demonstrates the actual Graph API request made by Intune admin center when updating a Windows Autopilot Device Preparation Policy, confirming that PUT is used instead of PATCH:


<img width="2358" height="308" alt="X-Ray" src="https://github.com/user-attachments/assets/c09719bd-3397-4da2-8900-37fd16f35808" />
