### PR TITLE
fix: use plain http.Client for Entra ID auth instead of Kiota client to fix missing grant_type with GitHub Actions OIDC

### DIFF
--- a/internal/client/entra_id_client_options.go
+++ b/internal/client/entra_id_client_options.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	khttp "github.com/microsoft/kiota-http-go"
 	"golang.org/x/exp/rand"
 )
 
@@ -127,38 +127,36 @@ func configureAuthTimeout(ctx context.Context, clientOptions *policy.ClientOptio
 
 func configureAuthClientProxy(ctx context.Context, config *ProviderData) (*http.Client, error) {
 	if config.ClientOptions.UseProxy && config.ClientOptions.ProxyURL != "" {
-		return configureProxyHTTPClient(ctx, config.ClientOptions)
+		return configureAuthProxyHTTPClient(ctx, config.ClientOptions)
 	}
 
 	tflog.Info(ctx, "Using default HTTP client without proxy")
-	return khttp.GetDefaultClient(), nil
+	// Use a plain http.Client without Kiota middleware.
+	// Kiota's GetDefaultClient() includes middleware (compression, retry, etc.)
+	// that can interfere with Azure SDK token endpoint requests by modifying the
+	// request body, causing the grant_type parameter to be lost.
+	return &http.Client{}, nil
 }
 
-func configureProxyHTTPClient(ctx context.Context, clientOptions *ClientOptions) (*http.Client, error) {
+func configureAuthProxyHTTPClient(ctx context.Context, clientOptions *ClientOptions) (*http.Client, error) {
 	tflog.Info(ctx, "Attempting to configure proxy with URL: "+clientOptions.ProxyURL)
 
-	var httpClient *http.Client
-	var err error
+	proxyURL, err := url.Parse(clientOptions.ProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse proxy URL: %w", err)
+	}
 
 	if clientOptions.ProxyUsername != "" && clientOptions.ProxyPassword != "" {
 		tflog.Info(ctx, "Configuring authenticated proxy")
-		httpClient, err = khttp.GetClientWithAuthenticatedProxySettings(
-			clientOptions.ProxyURL,
-			clientOptions.ProxyUsername,
-			clientOptions.ProxyPassword,
-		)
+		proxyURL.User = url.UserPassword(clientOptions.ProxyUsername, clientOptions.ProxyPassword)
 	} else {
 		tflog.Info(ctx, "Configuring unauthenticated proxy")
-		httpClient, err = khttp.GetClientWithProxySettings(
-			clientOptions.ProxyURL,
-		)
 	}
 
-	if err != nil {
-		tflog.Debug(ctx, fmt.Sprintf("Failed to create HTTP client with proxy settings: %v", err))
-		return nil, fmt.Errorf("unable to create HTTP client with proxy settings: %w", err)
+	transport := &http.Transport{
+		Proxy: http.ProxyURL(proxyURL),
 	}
 
 	tflog.Debug(ctx, "Proxy settings configured successfully")
-	return httpClient, nil
+	return &http.Client{Transport: transport}, nil
 }


### PR DESCRIPTION
# Pull Request Description

## Summary

Replace Kiota's `GetDefaultClient()` with a plain `http.Client` for the Entra ID authentication HTTP transport. Kiota's default client includes middleware (compression, retry, redirect, etc.) that interferes with Azure SDK token endpoint requests, causing the `grant_type` form parameter to be stripped from the request body.

### Issue Reference

Fixes #777

### Motivation and Context

- When using `oidc_github` authentication, the provider fails with `AADSTS900144: The request body must contain the following parameter: 'grant_type'`.
- The root cause is that `configureAuthClientProxy()` in `entra_id_client_options.go` uses `khttp.GetDefaultClient()` to create the HTTP client for Azure SDK authentication. This Kiota client includes a middleware pipeline (notably the compression handler) that modifies the form-encoded POST body sent to the Azure AD token endpoint (`/oauth2/v2.0/token`), causing Azure AD to be unable to parse the `grant_type` parameter.
- The fix replaces the Kiota HTTP client with a plain `http.Client` for the authentication transport, and also replaces the Kiota proxy helpers with standard `net/http` proxy configuration to avoid the same middleware issue in proxy scenarios.

### Dependencies

- No new dependencies required
- The `khttp` (kiota-http-go) import is removed from `entra_id_client_options.go` as it is no longer needed for the auth client
- No configuration changes needed

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

N/A

## Additional Notes

- The Kiota HTTP client (`khttp.GetDefaultClient()`) is designed for Microsoft Graph API calls and includes middleware such as compression, retry, redirect, parameter decoding, user agent, and headers inspection handlers. These middleware are appropriate for Graph API requests but not for Azure AD token endpoint requests made by the Azure SDK's `ClientAssertionCredential`.
- The proxy configuration was also updated to use standard `net/http` (`http.Transport` with `http.ProxyURL`) instead of Kiota's `GetClientWithProxySettings` / `GetClientWithAuthenticatedProxySettings`, which also included the problematic middleware pipeline.
- This issue affects all authentication methods that pass `ClientOptions` (with the Kiota transport) to the Azure SDK credential, including `oidc_github`, `oidc`, and `oidc_azure_devops`.
