### PR TITLE
fix: resource WindowsUpdatesAutopatchUpdatableAssetGroup state mapping

### DIFF
--- a/internal/services/resources/windows_updates/autopatch_updatable_asset_group/crud.go
+++ b/internal/services/resources/windows_updates/autopatch_updatable_asset_group/crud.go
@@ -99,6 +99,12 @@ func (r *WindowsUpdatesAutopatchUpdatableAssetGroupResource) Create(ctx context.
 			errors.HandleKiotaGraphError(ctx, err, resp, constants.TfOperationCreate, r.WritePermissions)
 			return
 		}
+
+		// Allow time for member enrollment to propagate before the read-back.
+		// The addMembersById endpoint is eventually consistent and members may not
+		// appear immediately in the GET members response.
+		tflog.Debug(ctx, "Waiting for member enrollment to propagate before read-back")
+		time.Sleep(20 * time.Second)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
@@ -345,6 +351,11 @@ func (r *WindowsUpdatesAutopatchUpdatableAssetGroupResource) Update(ctx context.
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Allow time for membership changes to propagate before the read-back.
+	// addMembersById and removeMembersById are eventually consistent.
+	tflog.Debug(ctx, "Waiting for membership changes to propagate before read-back")
+	time.Sleep(20 * time.Second)
 
 	readReq := resource.ReadRequest{State: resp.State, ProviderMeta: req.ProviderMeta}
 	stateContainer := &crud.UpdateResponseContainer{UpdateResponse: resp}

--- a/internal/services/resources/windows_updates/autopatch_updatable_asset_group/state.go
+++ b/internal/services/resources/windows_updates/autopatch_updatable_asset_group/state.go
@@ -67,7 +67,13 @@ func MapRemoteStateToTerraform(
 		return true
 	})
 
-	data.EntraDeviceObjectIds = types.SetValueMust(types.StringType, memberIDs)
+	// Only overwrite if there are members to record, or the config explicitly set an
+	// empty set (i.e. original was non-null). When the attribute was never set (null)
+	// and the API returns no members, preserve null so the plan/state comparison
+	// sees null==null rather than null!=[] and avoids an inconsistent-result error.
+	if len(memberIDs) > 0 || !data.EntraDeviceObjectIds.IsNull() {
+		data.EntraDeviceObjectIds = types.SetValueMust(types.StringType, memberIDs)
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Finished mapping remote state to Terraform state for %s", ResourceName))
 }


### PR DESCRIPTION
# Pull Request Description

## Summary

- Added a delay to allow time for member enrollment and membership changes to propagate before read-back operations, addressing eventual consistency issues with the addMembersById and removeMembersById endpoints.
- Updated state mapping logic to only overwrite EntraDeviceObjectIds if there are members to record or if the configuration explicitly sets an empty set, preserving null values for accurate plan/state comparisons.

### Issue Reference

Fixes #[Issue Number]

### Motivation and Context

- Why is this change needed?
- What problem does it solve?
- If it fixes an open issue, please link to the issue here

### Dependencies

- List any dependencies that are required for this change
- Include any configuration changes needed
- Note any version updates required

## Type of Change

Please mark the relevant option with an `x`:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist

- [ ] I have reviewed my own code before requesting review
- [ ] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [ ] My code follows the established style guidelines of this project
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
- [ ] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

[Add screenshots or recordings that demonstrate the changes]

## Additional Notes

[Add any additional information that might be helpful for reviewers]
