### PR TITLE
fix: OS version regex

### DIFF
--- a/internal/constants/regex.go
+++ b/internal/constants/regex.go
@@ -87,9 +87,9 @@ const (
 	// Example: "1.0.0.0"
 	VersionRegex = "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$"
 
-	// OSVersionRegex matches an operating system version string in the format "X.Y.Z.W" with any number of digits.
+	// OSVersionRegex matches an operating system version string in the format "X.Y.Z(+.W)" with any number of digits.
 	// Example: "10.0.22631.9999" or "1.1.1.1"
-	OSVersionRegex = `^\d+\.\d+\.\d+\.\d+$`
+	OSVersionRegex = `^\d+(\.\d+)*$` 
 
 	// SemVerRegex matches a Semantic Versioning string in the format "X.Y.Z" (Major.Minor.Patch).
 	// Examples: "1.0.0", "2.1.3", "10.20.30"


### PR DESCRIPTION
# Pull Request Description

## Summary

The change in this PR is to the regex of OS versions. Previously it only accepted OS versions with 4-part strings (e.g. 1.1.1.1). However on Microsoft Intune they allow the input of both 4-part strings and 3-part strings, meaning the resource needs to reflect that. If this isn't changed it can lead to unresolved drift when importing from Microsoft Intune. 

### Issue Reference

Fixes #[Issue Number]

### Motivation and Context

- This change is needed so the resource correctly reflects Microsoft Intune
- It solves the problem of the resource having different parameter requirements to Intune
- This will help when importing from Intune so there is no unresolved drift

### Dependencies

- List any dependencies that are required for this change
- Include any configuration changes needed
- Note any version updates required

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

[Add screenshots or recordings that demonstrate the changes]

## Additional Notes

[Add any additional information that might be helpful for reviewers]
