### PR TITLE
fix: verify group and user license assignment changes are actually applied before reporting success

### DIFF
--- a/internal/services/common/crud/poll.go
+++ b/internal/services/common/crud/poll.go
@@ -1,0 +1,60 @@
+package crud
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"time"
+)
+
+// FatalPollError marks an error returned by a PollUntil check as non-retryable,
+// aborting the poll loop immediately instead of waiting for the context deadline.
+type FatalPollError struct {
+	Err error
+}
+
+func (e *FatalPollError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *FatalPollError) Unwrap() error {
+	return e.Err
+}
+
+// PollUntil repeatedly invokes check every interval until check reports done, check returns
+// a *FatalPollError, or the context deadline is reached. It complements ReadWithRetry for
+// verification loops that cannot be expressed as a resource Read (e.g. polling until an
+// asynchronously-processed deletion is actually reflected by the API before removing the
+// resource from state).
+//
+// The check contract: return (true, nil) when the awaited condition holds; return
+// (false, err) with an err describing the still-pending condition (or the transient API
+// error) otherwise. The last such error is wrapped into the deadline error so the caller
+// can surface why the poll never completed. Wrap an error in *FatalPollError to abort
+// immediately on permanent failures (e.g. authorization errors).
+func PollUntil(ctx context.Context, interval time.Duration, check func(ctx context.Context) (bool, error)) error {
+	var lastErr error
+	for {
+		done, err := check(ctx)
+		if err != nil {
+			var fatal *FatalPollError
+			if stderrors.As(err, &fatal) {
+				return fatal.Err
+			}
+			lastErr = err
+		} else if done {
+			return nil
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			if lastErr != nil {
+				return fmt.Errorf("context deadline reached while polling: %w", lastErr)
+			}
+			return fmt.Errorf("context deadline reached while polling: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}

--- a/internal/services/resources/groups/graph_beta/license_assignment/crud.go
+++ b/internal/services/resources/groups/graph_beta/license_assignment/crud.go
@@ -195,12 +195,27 @@ func (r *GroupLicenseAssignmentResource) Read(ctx context.Context, req resource.
 	}
 
 	// The group existing is not enough — this resource represents a single license (SKU)
-	// on the group. When the SKU is absent from assignedLicenses, the license assignment
-	// does not exist, so remove it from state. During post-write ReadWithRetry polling this
-	// causes the consistency predicate to fail and the read to be retried, which is how a
-	// not-yet-propagated (or asynchronously failed) assignLicense is detected instead of
-	// being silently reported as successful.
+	// on the group. A single read that lacks the SKU is not authoritative, however:
+	// group license writes are asynchronous and reads can be served by lagging replicas.
+	// Before removing state, re-check until the read timeout expires so a transient stale
+	// read does not make Terraform forget a live license assignment and later try to delete
+	// the still-licensed group.
 	if found := MapRemoteResourceStateToTerraform(ctx, &object, group); !found {
+		if err := r.waitForLicensePresence(ctx, object.GroupId.ValueString(), object.SkuId.ValueString()); err == nil {
+			group, err = r.client.
+				Groups().
+				ByGroupId(object.GroupId.ValueString()).
+				Get(ctx, requestParameters)
+			if err != nil {
+				errors.HandleKiotaGraphError(ctx, err, resp, operation, r.ReadPermissions)
+				return
+			}
+			if found := MapRemoteResourceStateToTerraform(ctx, &object, group); found {
+				resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
+				return
+			}
+		}
+
 		tflog.Warn(ctx, fmt.Sprintf("License SKU %s is not assigned to group %s, removing %s from state",
 			object.SkuId.ValueString(), object.GroupId.ValueString(), ResourceName))
 		resp.State.RemoveResource(ctx)
@@ -385,6 +400,8 @@ func (r *GroupLicenseAssignmentResource) Delete(ctx context.Context, req resourc
 // being removed by the backend licensing service.
 func (r *GroupLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Context, groupID, skuID string) error {
 	const pollInterval = 5 * time.Second
+	const requiredAbsentReads = 2
+	absentReads := 0
 
 	requestParameters := &groups.GroupItemRequestBuilderGetRequestConfiguration{
 		QueryParameters: &groups.GroupItemRequestBuilderGetQueryParameters{
@@ -415,6 +432,7 @@ func (r *GroupLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Conte
 			return false, err
 		}
 
+		found := false
 		for _, license := range group.GetAssignedLicenses() {
 			if license == nil || license.GetSkuId() == nil {
 				continue
@@ -422,10 +440,57 @@ func (r *GroupLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Conte
 			// The API returns SKU ids in canonical lowercase form while the configured
 			// sku_id may use any casing, so compare case-insensitively.
 			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				found = true
+				absentReads = 0
 				tflog.Debug(ctx, fmt.Sprintf("License %s still assigned to group %s, waiting %s before re-checking", skuID, groupID, pollInterval))
 				return false, fmt.Errorf("license %s is still assigned to group %s", skuID, groupID)
 			}
 		}
+		if !found {
+			absentReads++
+		}
+		if absentReads < requiredAbsentReads {
+			return false, fmt.Errorf("license %s was absent from group %s on read %d/%d; confirming removal",
+				skuID, groupID, absentReads, requiredAbsentReads)
+		}
 		return true, nil
+	})
+}
+
+// waitForLicensePresence polls until the given SKU is visible in assignedLicenses. It is
+// used by Read before removing state so one stale read cannot turn an eventually-consistent
+// live assignment into Terraform drift.
+func (r *GroupLicenseAssignmentResource) waitForLicensePresence(ctx context.Context, groupID, skuID string) error {
+	const pollInterval = 5 * time.Second
+
+	requestParameters := &groups.GroupItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &groups.GroupItemRequestBuilderGetQueryParameters{
+			Select: []string{"id", "assignedLicenses"},
+		},
+	}
+
+	return crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
+		group, err := r.client.
+			Groups().
+			ByGroupId(groupID).
+			Get(ctx, requestParameters)
+
+		if err != nil {
+			errorInfo := errors.GraphError(ctx, err)
+			if errors.IsNonRetryableReadError(&errorInfo) {
+				return false, &crud.FatalPollError{Err: err}
+			}
+			return false, err
+		}
+
+		for _, license := range group.GetAssignedLicenses() {
+			if license == nil || license.GetSkuId() == nil {
+				continue
+			}
+			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("license %s is not yet visible on group %s", skuID, groupID)
 	})
 }

--- a/internal/services/resources/groups/graph_beta/license_assignment/crud.go
+++ b/internal/services/resources/groups/graph_beta/license_assignment/crud.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/groups"
+	graphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
 )
 
 // groupLicenseLocks serializes assignLicense operations per group.
@@ -201,16 +202,8 @@ func (r *GroupLicenseAssignmentResource) Read(ctx context.Context, req resource.
 	// read does not make Terraform forget a live license assignment and later try to delete
 	// the still-licensed group.
 	if found := MapRemoteResourceStateToTerraform(ctx, &object, group); !found {
-		if err := r.waitForLicensePresence(ctx, object.GroupId.ValueString(), object.SkuId.ValueString()); err == nil {
-			group, err = r.client.
-				Groups().
-				ByGroupId(object.GroupId.ValueString()).
-				Get(ctx, requestParameters)
-			if err != nil {
-				errors.HandleKiotaGraphError(ctx, err, resp, operation, r.ReadPermissions)
-				return
-			}
-			if found := MapRemoteResourceStateToTerraform(ctx, &object, group); found {
+		if confirmedGroup, err := r.waitForLicensePresence(ctx, object.GroupId.ValueString(), object.SkuId.ValueString()); err == nil {
+			if found := MapRemoteResourceStateToTerraform(ctx, &object, confirmedGroup); found {
 				resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
 				return
 			}
@@ -460,16 +453,17 @@ func (r *GroupLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Conte
 // waitForLicensePresence polls until the given SKU is visible in assignedLicenses. It is
 // used by Read before removing state so one stale read cannot turn an eventually-consistent
 // live assignment into Terraform drift.
-func (r *GroupLicenseAssignmentResource) waitForLicensePresence(ctx context.Context, groupID, skuID string) error {
+func (r *GroupLicenseAssignmentResource) waitForLicensePresence(ctx context.Context, groupID, skuID string) (graphmodels.Groupable, error) {
 	const pollInterval = 5 * time.Second
+	var confirmedGroup graphmodels.Groupable
 
 	requestParameters := &groups.GroupItemRequestBuilderGetRequestConfiguration{
 		QueryParameters: &groups.GroupItemRequestBuilderGetQueryParameters{
-			Select: []string{"id", "assignedLicenses"},
+			Select: []string{"id", "displayName", "assignedLicenses"},
 		},
 	}
 
-	return crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
+	err := crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
 		group, err := r.client.
 			Groups().
 			ByGroupId(groupID).
@@ -488,9 +482,14 @@ func (r *GroupLicenseAssignmentResource) waitForLicensePresence(ctx context.Cont
 				continue
 			}
 			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				confirmedGroup = group
 				return true, nil
 			}
 		}
 		return false, fmt.Errorf("license %s is not yet visible on group %s", skuID, groupID)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return confirmedGroup, nil
 }

--- a/internal/services/resources/groups/graph_beta/license_assignment/crud.go
+++ b/internal/services/resources/groups/graph_beta/license_assignment/crud.go
@@ -3,6 +3,8 @@ package graphBetaGroupLicenseAssignment
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
@@ -15,6 +17,43 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/groups"
 )
+
+// groupLicenseLocks serializes assignLicense operations per group.
+//
+// The assignLicense endpoint mutates the group's whole license set and is asynchronous:
+// it returns 202 Accepted and the actual add/remove is applied later by the backend
+// licensing service (see the Response section of
+// https://learn.microsoft.com/en-us/graph/api/group-assignlicense?view=graph-rest-beta).
+// Microsoft documents that group license processing takes time to complete and can fail
+// after the request was accepted:
+//   - https://learn.microsoft.com/en-us/entra/identity/users/licensing-group-advanced
+//     ("How long does it take for licenses to be modified after group changes")
+//   - https://learn.microsoft.com/en-us/entra/fundamentals/licensing-groups-resolve-problems
+//
+// There is no official documentation of the concurrency semantics of overlapping
+// assignLicense calls against the same group. Because each call rewrites the same license
+// set asynchronously, concurrent POSTs from multiple Terraform resources targeting the same
+// group (Terraform applies resources in parallel by default) have been observed in the field
+// to silently lose adds or removes. Serializing per group is therefore a defensive measure
+// consistent with Microsoft's eventual-consistency guidance for Entra
+// (https://devblogs.microsoft.com/identity/designing-for-eventual-consistency-for-microsoft-entra/):
+// each Create/Update/Delete takes the group's lock and holds it until the change is
+// confirmed by a read-back.
+var groupLicenseLocks sync.Map // group id -> *sync.Mutex
+
+// lockGroupLicense acquires the per-group license lock and returns the unlock func.
+// Callers acquire it before starting their operation timeout so time spent waiting on
+// sibling license assignments does not consume the resource's own timeout budget.
+func lockGroupLicense(ctx context.Context, groupID string) func() {
+	m, _ := groupLicenseLocks.LoadOrStore(groupID, &sync.Mutex{})
+	mu := m.(*sync.Mutex)
+	start := time.Now()
+	mu.Lock()
+	if waited := time.Since(start); waited > time.Second {
+		tflog.Debug(ctx, fmt.Sprintf("Waited %s for the license assignment lock on group %s", waited, groupID))
+	}
+	return mu.Unlock
+}
 
 // Create handles the Create operation for Group License Assignment resources.
 //
@@ -32,6 +71,10 @@ func (r *GroupLicenseAssignmentResource) Create(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Serialize with sibling license assignments targeting the same group (see groupLicenseLocks).
+	unlock := lockGroupLicense(ctx, object.GroupId.ValueString())
+	defer unlock()
 
 	ctx, cancel := crud.HandleTimeout(ctx, object.Timeouts.Create, CreateTimeout*time.Second, &resp.Diagnostics)
 	if cancel == nil {
@@ -151,7 +194,18 @@ func (r *GroupLicenseAssignmentResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	MapRemoteResourceStateToTerraform(ctx, &object, group)
+	// The group existing is not enough — this resource represents a single license (SKU)
+	// on the group. When the SKU is absent from assignedLicenses, the license assignment
+	// does not exist, so remove it from state. During post-write ReadWithRetry polling this
+	// causes the consistency predicate to fail and the read to be retried, which is how a
+	// not-yet-propagated (or asynchronously failed) assignLicense is detected instead of
+	// being silently reported as successful.
+	if found := MapRemoteResourceStateToTerraform(ctx, &object, group); !found {
+		tflog.Warn(ctx, fmt.Sprintf("License SKU %s is not assigned to group %s, removing %s from state",
+			object.SkuId.ValueString(), object.GroupId.ValueString(), ResourceName))
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
 	if resp.Diagnostics.HasError() {
@@ -178,6 +232,10 @@ func (r *GroupLicenseAssignmentResource) Update(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Serialize with sibling license assignments targeting the same group (see groupLicenseLocks).
+	unlock := lockGroupLicense(ctx, plan.GroupId.ValueString())
+	defer unlock()
 
 	ctx, cancel := crud.HandleTimeout(ctx, plan.Timeouts.Update, UpdateTimeout*time.Second, &resp.Diagnostics)
 	if cancel == nil {
@@ -240,7 +298,20 @@ func (r *GroupLicenseAssignmentResource) Update(ctx context.Context, req resourc
 //   - POST /groups/{groupId}/assignLicense (with removeLicenses parameter)
 //
 // Reference: https://learn.microsoft.com/en-us/graph/api/group-assignlicense?view=graph-rest-beta
-// Note: Uses same assignLicense endpoint with removeLicenses to remove the license
+// Note: Uses same assignLicense endpoint with removeLicenses to remove the license.
+// assignLicense is asynchronous — it returns 202 Accepted and the removal is processed later
+// by the backend licensing service (https://learn.microsoft.com/en-us/graph/api/group-assignlicense?view=graph-rest-beta).
+// Microsoft documents that a group cannot be deleted until license removal processing has
+// actually completed ("A group with active licenses assigned cannot be deleted"), and that
+// removals can fail after being accepted, e.g. when removed SKUs contain service plans that
+// other assigned SKUs depend on:
+//   - https://learn.microsoft.com/en-us/entra/fundamentals/licensing-groups-resolve-problems
+//   - https://learn.microsoft.com/en-us/answers/questions/2006508/how-to-remove-multiple-licenses-from-a-security-gr
+//
+// Delete therefore polls the group's assignedLicenses until the SKU is actually gone before
+// removing the resource from state. Returning early on the 202 would let a dependent group
+// deletion run while the group still has active licenses, and a silently failed removal would
+// be unrecoverable via Terraform because the resource would already be gone from state.
 func (r *GroupLicenseAssignmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var object GroupLicenseAssignmentResourceModel
 
@@ -250,6 +321,10 @@ func (r *GroupLicenseAssignmentResource) Delete(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Serialize with sibling license assignments targeting the same group (see groupLicenseLocks).
+	unlock := lockGroupLicense(ctx, object.GroupId.ValueString())
+	defer unlock()
 
 	ctx, cancel := crud.HandleTimeout(ctx, object.Timeouts.Delete, DeleteTimeout*time.Second, &resp.Diagnostics)
 	if cancel == nil {
@@ -278,6 +353,23 @@ func (r *GroupLicenseAssignmentResource) Delete(ctx context.Context, req resourc
 		return
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("License removal request accepted for license %s on group: %s, waiting for removal to complete",
+		object.SkuId.ValueString(), object.GroupId.ValueString()))
+
+	if err := r.waitForLicenseRemoval(ctx, object.GroupId.ValueString(), object.SkuId.ValueString()); err != nil {
+		resp.Diagnostics.AddError(
+			"License removal did not complete",
+			fmt.Sprintf("The removal of license %s from group %s was accepted by the API but the license "+
+				"is still assigned after waiting. Group license processing is asynchronous and can fail "+
+				"silently (e.g. when removed SKUs contain service plans that other assigned SKUs depend on) "+
+				"or become stuck. Check the group's license processing state in the Microsoft Entra portal "+
+				"and reprocess if needed, then retry. The resource has been kept in Terraform state so the "+
+				"removal can be retried. Error: %s",
+				object.SkuId.ValueString(), object.GroupId.ValueString(), err.Error()),
+		)
+		return
+	}
+
 	tflog.Debug(ctx, fmt.Sprintf("Successfully removed license %s from group: %s", object.SkuId.ValueString(), object.GroupId.ValueString()))
 
 	tflog.Debug(ctx, fmt.Sprintf("Removing %s from Terraform state", ResourceName))
@@ -285,4 +377,55 @@ func (r *GroupLicenseAssignmentResource) Delete(ctx context.Context, req resourc
 	resp.State.RemoveResource(ctx)
 
 	tflog.Debug(ctx, fmt.Sprintf("Finished Delete Method: %s", ResourceName))
+}
+
+// waitForLicenseRemoval polls the group's assignedLicenses until the given SKU is no longer
+// present, the group itself is gone (404), or the context deadline is reached. This closes the
+// gap between the asynchronous 202 Accepted returned by assignLicense and the license actually
+// being removed by the backend licensing service.
+func (r *GroupLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Context, groupID, skuID string) error {
+	const pollInterval = 5 * time.Second
+
+	requestParameters := &groups.GroupItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &groups.GroupItemRequestBuilderGetQueryParameters{
+			Select: []string{"id", "assignedLicenses"},
+		},
+	}
+
+	return crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
+		group, err := r.client.
+			Groups().
+			ByGroupId(groupID).
+			Get(ctx, requestParameters)
+
+		if err != nil {
+			errorInfo := errors.GraphError(ctx, err)
+			if errorInfo.StatusCode == 404 {
+				tflog.Debug(ctx, fmt.Sprintf("Group %s no longer exists, treating license removal as complete", groupID))
+				return true, nil
+			}
+			// Permanent errors (authorization, bad request, ...) will not resolve by
+			// polling — fail fast instead of consuming the whole delete timeout.
+			if errors.IsNonRetryableReadError(&errorInfo) {
+				return false, &crud.FatalPollError{Err: err}
+			}
+			// Transient read errors should not fail the delete outright — keep polling
+			// until the deadline and surface the last error if the wait times out.
+			tflog.Debug(ctx, fmt.Sprintf("Error reading group %s while waiting for license removal, will retry: %s", groupID, err.Error()))
+			return false, err
+		}
+
+		for _, license := range group.GetAssignedLicenses() {
+			if license == nil || license.GetSkuId() == nil {
+				continue
+			}
+			// The API returns SKU ids in canonical lowercase form while the configured
+			// sku_id may use any casing, so compare case-insensitively.
+			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				tflog.Debug(ctx, fmt.Sprintf("License %s still assigned to group %s, waiting %s before re-checking", skuID, groupID, pollInterval))
+				return false, fmt.Errorf("license %s is still assigned to group %s", skuID, groupID)
+			}
+		}
+		return true, nil
+	})
 }

--- a/internal/services/resources/groups/graph_beta/license_assignment/predicate.go
+++ b/internal/services/resources/groups/graph_beta/license_assignment/predicate.go
@@ -2,35 +2,47 @@ package graphBetaGroupLicenseAssignment
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // groupLicenseAssignmentConsistencyPredicate returns a consistency predicate for ReadWithRetry
 // that verifies the complete group license assignment resource state has propagated across
 // Microsoft Entra replicas before accepting the read as authoritative.
 //
-// Microsoft Entra uses an eventually consistent, multi-replica architecture. After a successful
-// assignLicense POST (2xx), reads may be served from a replica that has not yet received the
-// write. Any field in the resource could reflect pre-write stale data during this window.
+// Microsoft Entra uses an eventually consistent, multi-replica architecture, and assignLicense
+// itself is asynchronous (202 Accepted): after a successful POST, reads may be served from a
+// replica that has not yet received the write, or the backend licensing service may not have
+// processed the change yet. Any field in the resource could reflect pre-write stale data during
+// this window.
 //
 // The predicate compares the full read state against the expected state captured at write time:
 //
+//   - the state must not be null — Read removes the resource from state when the managed SKU
+//     is absent from the group's assignedLicenses, so a null state means the assignment has
+//     not been observed on the responding replica yet. This is the primary signal that the
+//     asynchronous assignLicense processing has not completed (or has silently failed).
 //   - display_name must be populated — a Computed field only set by a real API read,
 //     so null/unknown indicates the read state has not yet been refreshed from the API.
 //   - id must be non-empty — confirms the composite groupId_skuId key resolved correctly.
 //   - group_id must match — confirms the read is for the correct group object.
 //   - sku_id must match — confirms the correct license SKU is tracked in state.
-//   - disabled_plans count must match — when the SKU is not yet visible in assignedLicenses
-//     on the responding replica, MapRemoteResourceStateToTerraform defaults disabled_plans
-//     to an empty set regardless of what was written. A count mismatch is the primary signal
-//     that the assignedLicenses list has not yet converged on the responding replica.
+//   - disabled_plans must match as a set — confirms the disabled plans visible on the
+//     responding replica are exactly the ones that were written, not stale pre-write data.
 //
 // Retries continue until all conditions are satisfied or the context deadline is reached,
 // implementing the polling pattern recommended by Microsoft for Entra eventual consistency:
 // https://devblogs.microsoft.com/identity/designing-for-eventual-consistency-for-microsoft-entra/
 func groupLicenseAssignmentConsistencyPredicate(expected *GroupLicenseAssignmentResourceModel) func(ctx context.Context, state tfsdk.State) bool {
 	return func(ctx context.Context, state tfsdk.State) bool {
+		// Read removes the resource from state when the managed SKU is not present in the
+		// group's assignedLicenses. Treat that as "write not yet confirmed" and keep polling.
+		if state.Raw.IsNull() {
+			return false
+		}
+
 		var actual GroupLicenseAssignmentResourceModel
 		if diags := state.Get(ctx, &actual); diags.HasError() {
 			return false
@@ -57,13 +69,38 @@ func groupLicenseAssignmentConsistencyPredicate(expected *GroupLicenseAssignment
 			return false
 		}
 
-		// disabled_plans count must match the written value. When the SKU is not yet visible
-		// in assignedLicenses on the responding replica, MapRemoteResourceStateToTerraform
-		// defaults disabled_plans to an empty set regardless of what was written.
-		expectedCount := len(expected.DisabledPlans.Elements())
-		if actual.DisabledPlans.IsNull() || actual.DisabledPlans.IsUnknown() {
-			return expectedCount == 0
-		}
-		return len(actual.DisabledPlans.Elements()) == expectedCount
+		// disabled_plans must match the written value as a set, so that stale pre-write
+		// data with the same cardinality but different plan IDs is not accepted.
+		return uuidSetsEqual(expected.DisabledPlans, actual.DisabledPlans)
 	}
+}
+
+// uuidSetsEqual compares two types.Set values of UUID strings for set equality, treating
+// null/unknown as the empty set. UUIDs are compared case-insensitively: the API returns
+// them in canonical lowercase form while the configured values may use any casing.
+func uuidSetsEqual(a, b types.Set) bool {
+	aElems := setElementsAsLowercaseStrings(a)
+	bElems := setElementsAsLowercaseStrings(b)
+	if len(aElems) != len(bElems) {
+		return false
+	}
+	for elem := range aElems {
+		if !bElems[elem] {
+			return false
+		}
+	}
+	return true
+}
+
+func setElementsAsLowercaseStrings(s types.Set) map[string]bool {
+	result := make(map[string]bool)
+	if s.IsNull() || s.IsUnknown() {
+		return result
+	}
+	for _, elem := range s.Elements() {
+		if strVal, ok := elem.(types.String); ok {
+			result[strings.ToLower(strVal.ValueString())] = true
+		}
+	}
+	return result
 }

--- a/internal/services/resources/groups/graph_beta/license_assignment/state.go
+++ b/internal/services/resources/groups/graph_beta/license_assignment/state.go
@@ -3,6 +3,7 @@ package graphBetaGroupLicenseAssignment
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 	"github.com/google/uuid"
@@ -21,10 +22,13 @@ func uuidPointerToStringValue(uuidPtr *uuid.UUID) types.String {
 }
 
 // MapRemoteResourceStateToTerraform maps the properties of a Group to Terraform state for license assignment.
-func MapRemoteResourceStateToTerraform(ctx context.Context, data *GroupLicenseAssignmentResourceModel, remoteResource graphmodels.Groupable) {
+// It returns true when the managed SKU is present in the group's assignedLicenses, and false when
+// the group exists but the license assignment does not — callers use this to distinguish
+// "group found" from "license assignment found".
+func MapRemoteResourceStateToTerraform(ctx context.Context, data *GroupLicenseAssignmentResourceModel, remoteResource graphmodels.Groupable) bool {
 	if remoteResource == nil {
 		tflog.Debug(ctx, "Remote resource is nil")
-		return
+		return false
 	}
 
 	tflog.Debug(ctx, "Starting to map remote state to Terraform state", map[string]any{
@@ -43,6 +47,7 @@ func MapRemoteResourceStateToTerraform(ctx context.Context, data *GroupLicenseAs
 	// propagation delay) we don't leave stale disabled-plan data in state.
 	data.DisabledPlans = types.SetValueMust(types.StringType, []attr.Value{})
 
+	skuFound := false
 	for _, license := range assignedLicenses {
 		if license == nil {
 			continue
@@ -50,11 +55,14 @@ func MapRemoteResourceStateToTerraform(ctx context.Context, data *GroupLicenseAs
 
 		licenseSkuId := uuidPointerToStringValue(license.GetSkuId())
 		tflog.Debug(ctx, fmt.Sprintf("Checking license SKU: %s (looking for: %s)", licenseSkuId.ValueString(), managedSkuId))
-		
-		if licenseSkuId.ValueString() == managedSkuId {
+
+		// The API returns SKU ids in canonical lowercase form while the configured
+		// sku_id may use any casing, so compare case-insensitively.
+		if strings.EqualFold(licenseSkuId.ValueString(), managedSkuId) {
+			skuFound = true
 			disabledPlans := license.GetDisabledPlans()
 			tflog.Debug(ctx, fmt.Sprintf("Found matching license, disabled plans count: %d", len(disabledPlans)))
-			
+
 			disabledPlanValues := make([]attr.Value, 0, len(disabledPlans))
 			for _, planUUID := range disabledPlans {
 				planStr := planUUID.String()
@@ -66,8 +74,10 @@ func MapRemoteResourceStateToTerraform(ctx context.Context, data *GroupLicenseAs
 			break
 		}
 	}
-	
+
 	tflog.Debug(ctx, fmt.Sprintf("Final disabled_plans in state: %v", data.DisabledPlans))
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished mapping group license assignment resource with id %s", data.ID.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("Finished mapping group license assignment resource with id %s (sku found: %t)", data.ID.ValueString(), skuFound))
+
+	return skuFound
 }

--- a/internal/services/resources/users/graph_beta/license_assignment/crud.go
+++ b/internal/services/resources/users/graph_beta/license_assignment/crud.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	graphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/users"
 )
 
@@ -192,16 +193,8 @@ func (r *UserLicenseAssignmentResource) Read(ctx context.Context, req resource.R
 	// be served by lagging replicas. Before removing state, re-check until the read timeout
 	// expires so a transient stale read does not make Terraform forget a live assignment.
 	if found := MapRemoteResourceStateToTerraform(ctx, &object, user); !found {
-		if err := r.waitForLicensePresence(ctx, object.UserId.ValueString(), object.SkuId.ValueString()); err == nil {
-			user, err = r.client.
-				Users().
-				ByUserId(object.UserId.ValueString()).
-				Get(ctx, requestParameters)
-			if err != nil {
-				errors.HandleKiotaGraphError(ctx, err, resp, operation, r.ReadPermissions)
-				return
-			}
-			if found := MapRemoteResourceStateToTerraform(ctx, &object, user); found {
+		if confirmedUser, err := r.waitForLicensePresence(ctx, object.UserId.ValueString(), object.SkuId.ValueString()); err == nil {
+			if found := MapRemoteResourceStateToTerraform(ctx, &object, confirmedUser); found {
 				resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
 				return
 			}
@@ -439,16 +432,17 @@ func (r *UserLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Contex
 // waitForLicensePresence polls until the given SKU is visible in assignedLicenses. It is
 // used by Read before removing state so one stale read cannot turn an eventually-consistent
 // live assignment into Terraform drift.
-func (r *UserLicenseAssignmentResource) waitForLicensePresence(ctx context.Context, userID, skuID string) error {
+func (r *UserLicenseAssignmentResource) waitForLicensePresence(ctx context.Context, userID, skuID string) (graphmodels.Userable, error) {
 	const pollInterval = 5 * time.Second
+	var confirmedUser graphmodels.Userable
 
 	requestParameters := &users.UserItemRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.UserItemRequestBuilderGetQueryParameters{
-			Select: []string{"id", "assignedLicenses"},
+			Select: []string{"id", "userPrincipalName", "assignedLicenses"},
 		},
 	}
 
-	return crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
+	err := crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
 		user, err := r.client.
 			Users().
 			ByUserId(userID).
@@ -467,9 +461,14 @@ func (r *UserLicenseAssignmentResource) waitForLicensePresence(ctx context.Conte
 				continue
 			}
 			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				confirmedUser = user
 				return true, nil
 			}
 		}
 		return false, fmt.Errorf("license %s is not yet visible on user %s", skuID, userID)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return confirmedUser, nil
 }

--- a/internal/services/resources/users/graph_beta/license_assignment/crud.go
+++ b/internal/services/resources/users/graph_beta/license_assignment/crud.go
@@ -188,12 +188,25 @@ func (r *UserLicenseAssignmentResource) Read(ctx context.Context, req resource.R
 	}
 
 	// The user existing is not enough — this resource represents a single license (SKU)
-	// on the user. When the SKU is absent from assignedLicenses, the license assignment
-	// does not exist, so remove it from state. During post-write ReadWithRetry polling this
-	// causes the consistency predicate to fail and the read to be retried, which is how a
-	// not-yet-propagated (or failed) assignLicense is detected instead of being silently
-	// reported as successful.
+	// on the user. A single read that lacks the SKU is not authoritative because reads can
+	// be served by lagging replicas. Before removing state, re-check until the read timeout
+	// expires so a transient stale read does not make Terraform forget a live assignment.
 	if found := MapRemoteResourceStateToTerraform(ctx, &object, user); !found {
+		if err := r.waitForLicensePresence(ctx, object.UserId.ValueString(), object.SkuId.ValueString()); err == nil {
+			user, err = r.client.
+				Users().
+				ByUserId(object.UserId.ValueString()).
+				Get(ctx, requestParameters)
+			if err != nil {
+				errors.HandleKiotaGraphError(ctx, err, resp, operation, r.ReadPermissions)
+				return
+			}
+			if found := MapRemoteResourceStateToTerraform(ctx, &object, user); found {
+				resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
+				return
+			}
+		}
+
 		tflog.Warn(ctx, fmt.Sprintf("License SKU %s is not assigned to user %s, removing %s from state",
 			object.SkuId.ValueString(), object.UserId.ValueString(), ResourceName))
 		resp.State.RemoveResource(ctx)
@@ -366,6 +379,8 @@ func (r *UserLicenseAssignmentResource) Delete(ctx context.Context, req resource
 // (e.g. deleting the user's last license before disabling the account) observe stale data.
 func (r *UserLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Context, userID, skuID string) error {
 	const pollInterval = 5 * time.Second
+	const requiredAbsentReads = 2
+	absentReads := 0
 
 	requestParameters := &users.UserItemRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.UserItemRequestBuilderGetQueryParameters{
@@ -396,6 +411,7 @@ func (r *UserLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Contex
 			return false, err
 		}
 
+		found := false
 		for _, license := range user.GetAssignedLicenses() {
 			if license == nil || license.GetSkuId() == nil {
 				continue
@@ -403,10 +419,57 @@ func (r *UserLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Contex
 			// The API returns SKU ids in canonical lowercase form while the configured
 			// sku_id may use any casing, so compare case-insensitively.
 			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				found = true
+				absentReads = 0
 				tflog.Debug(ctx, fmt.Sprintf("License %s still assigned to user %s, waiting %s before re-checking", skuID, userID, pollInterval))
 				return false, fmt.Errorf("license %s is still assigned to user %s", skuID, userID)
 			}
 		}
+		if !found {
+			absentReads++
+		}
+		if absentReads < requiredAbsentReads {
+			return false, fmt.Errorf("license %s was absent from user %s on read %d/%d; confirming removal",
+				skuID, userID, absentReads, requiredAbsentReads)
+		}
 		return true, nil
+	})
+}
+
+// waitForLicensePresence polls until the given SKU is visible in assignedLicenses. It is
+// used by Read before removing state so one stale read cannot turn an eventually-consistent
+// live assignment into Terraform drift.
+func (r *UserLicenseAssignmentResource) waitForLicensePresence(ctx context.Context, userID, skuID string) error {
+	const pollInterval = 5 * time.Second
+
+	requestParameters := &users.UserItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.UserItemRequestBuilderGetQueryParameters{
+			Select: []string{"id", "assignedLicenses"},
+		},
+	}
+
+	return crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
+		user, err := r.client.
+			Users().
+			ByUserId(userID).
+			Get(ctx, requestParameters)
+
+		if err != nil {
+			errorInfo := errors.GraphError(ctx, err)
+			if errors.IsNonRetryableReadError(&errorInfo) {
+				return false, &crud.FatalPollError{Err: err}
+			}
+			return false, err
+		}
+
+		for _, license := range user.GetAssignedLicenses() {
+			if license == nil || license.GetSkuId() == nil {
+				continue
+			}
+			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("license %s is not yet visible on user %s", skuID, userID)
 	})
 }

--- a/internal/services/resources/users/graph_beta/license_assignment/crud.go
+++ b/internal/services/resources/users/graph_beta/license_assignment/crud.go
@@ -3,6 +3,8 @@ package graphBetaUserLicenseAssignment
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
@@ -15,6 +17,35 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/users"
 )
+
+// userLicenseLocks serializes assignLicense operations per user.
+//
+// The assignLicense endpoint mutates the user's whole license set
+// (https://learn.microsoft.com/en-us/graph/api/user-assignlicense?view=graph-rest-beta),
+// and Microsoft Entra is an eventually consistent, multi-replica system
+// (https://devblogs.microsoft.com/identity/designing-for-eventual-consistency-for-microsoft-entra/).
+// There is no official documentation of the concurrency semantics of overlapping
+// assignLicense calls against the same user; because each call rewrites the same license
+// set, concurrent POSTs from multiple Terraform resources targeting the same user
+// (Terraform applies resources in parallel by default) risk losing adds or removes, the
+// same failure mode observed in the field for the group variant of this resource.
+// Each Create/Update/Delete takes the user's lock and holds it until the change is
+// confirmed by a read-back.
+var userLicenseLocks sync.Map // user id -> *sync.Mutex
+
+// lockUserLicense acquires the per-user license lock and returns the unlock func.
+// Callers acquire it before starting their operation timeout so time spent waiting on
+// sibling license assignments does not consume the resource's own timeout budget.
+func lockUserLicense(ctx context.Context, userID string) func() {
+	m, _ := userLicenseLocks.LoadOrStore(userID, &sync.Mutex{})
+	mu := m.(*sync.Mutex)
+	start := time.Now()
+	mu.Lock()
+	if waited := time.Since(start); waited > time.Second {
+		tflog.Debug(ctx, fmt.Sprintf("Waited %s for the license assignment lock on user %s", waited, userID))
+	}
+	return mu.Unlock
+}
 
 // Create handles the Create operation for user license assignment resources.
 //
@@ -33,6 +64,10 @@ func (r *UserLicenseAssignmentResource) Create(ctx context.Context, req resource
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Serialize with sibling license assignments targeting the same user (see userLicenseLocks).
+	unlock := lockUserLicense(ctx, object.UserId.ValueString())
+	defer unlock()
 
 	ctx, cancel := crud.HandleTimeout(ctx, object.Timeouts.Create, CreateTimeout*time.Second, &resp.Diagnostics)
 	if cancel == nil {
@@ -152,7 +187,18 @@ func (r *UserLicenseAssignmentResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	MapRemoteResourceStateToTerraform(ctx, &object, user)
+	// The user existing is not enough — this resource represents a single license (SKU)
+	// on the user. When the SKU is absent from assignedLicenses, the license assignment
+	// does not exist, so remove it from state. During post-write ReadWithRetry polling this
+	// causes the consistency predicate to fail and the read to be retried, which is how a
+	// not-yet-propagated (or failed) assignLicense is detected instead of being silently
+	// reported as successful.
+	if found := MapRemoteResourceStateToTerraform(ctx, &object, user); !found {
+		tflog.Warn(ctx, fmt.Sprintf("License SKU %s is not assigned to user %s, removing %s from state",
+			object.SkuId.ValueString(), object.UserId.ValueString(), ResourceName))
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
 	if resp.Diagnostics.HasError() {
@@ -179,6 +225,10 @@ func (r *UserLicenseAssignmentResource) Update(ctx context.Context, req resource
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Serialize with sibling license assignments targeting the same user (see userLicenseLocks).
+	unlock := lockUserLicense(ctx, plan.UserId.ValueString())
+	defer unlock()
 
 	ctx, cancel := crud.HandleTimeout(ctx, plan.Timeouts.Update, UpdateTimeout*time.Second, &resp.Diagnostics)
 	if cancel == nil {
@@ -252,6 +302,10 @@ func (r *UserLicenseAssignmentResource) Delete(ctx context.Context, req resource
 		return
 	}
 
+	// Serialize with sibling license assignments targeting the same user (see userLicenseLocks).
+	unlock := lockUserLicense(ctx, object.UserId.ValueString())
+	defer unlock()
+
 	ctx, cancel := crud.HandleTimeout(ctx, object.Timeouts.Delete, DeleteTimeout*time.Second, &resp.Diagnostics)
 	if cancel == nil {
 		return
@@ -279,6 +333,21 @@ func (r *UserLicenseAssignmentResource) Delete(ctx context.Context, req resource
 		return
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("License removal request accepted for license %s on user: %s, waiting for removal to be reflected",
+		object.SkuId.ValueString(), object.UserId.ValueString()))
+
+	if err := r.waitForLicenseRemoval(ctx, object.UserId.ValueString(), object.SkuId.ValueString()); err != nil {
+		resp.Diagnostics.AddError(
+			"License removal did not complete",
+			fmt.Sprintf("The removal of license %s from user %s was accepted by the API but the license "+
+				"is still assigned after waiting. If the license is inherited from a group the user is a "+
+				"member of, it cannot be removed directly — remove it from the group instead. The resource "+
+				"has been kept in Terraform state so the removal can be retried. Error: %s",
+				object.SkuId.ValueString(), object.UserId.ValueString(), err.Error()),
+		)
+		return
+	}
+
 	tflog.Debug(ctx, fmt.Sprintf("Successfully removed license %s from user: %s", object.SkuId.ValueString(), object.UserId.ValueString()))
 
 	tflog.Debug(ctx, fmt.Sprintf("Removing %s from Terraform state", ResourceName))
@@ -286,4 +355,58 @@ func (r *UserLicenseAssignmentResource) Delete(ctx context.Context, req resource
 	resp.State.RemoveResource(ctx)
 
 	tflog.Debug(ctx, fmt.Sprintf("Finished Delete Method: %s", ResourceName))
+}
+
+// waitForLicenseRemoval polls the user's assignedLicenses until the given SKU is no longer
+// present, the user itself is gone (404), or the context deadline is reached. Unlike the
+// group variant, user assignLicense applies synchronously (200 OK), but reads may still be
+// served from a replica that has not yet received the write
+// (https://devblogs.microsoft.com/identity/designing-for-eventual-consistency-for-microsoft-entra/),
+// so removing the resource from state without confirming would let a dependent operation
+// (e.g. deleting the user's last license before disabling the account) observe stale data.
+func (r *UserLicenseAssignmentResource) waitForLicenseRemoval(ctx context.Context, userID, skuID string) error {
+	const pollInterval = 5 * time.Second
+
+	requestParameters := &users.UserItemRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.UserItemRequestBuilderGetQueryParameters{
+			Select: []string{"id", "assignedLicenses"},
+		},
+	}
+
+	return crud.PollUntil(ctx, pollInterval, func(ctx context.Context) (bool, error) {
+		user, err := r.client.
+			Users().
+			ByUserId(userID).
+			Get(ctx, requestParameters)
+
+		if err != nil {
+			errorInfo := errors.GraphError(ctx, err)
+			if errorInfo.StatusCode == 404 {
+				tflog.Debug(ctx, fmt.Sprintf("User %s no longer exists, treating license removal as complete", userID))
+				return true, nil
+			}
+			// Permanent errors (authorization, bad request, ...) will not resolve by
+			// polling — fail fast instead of consuming the whole delete timeout.
+			if errors.IsNonRetryableReadError(&errorInfo) {
+				return false, &crud.FatalPollError{Err: err}
+			}
+			// Transient read errors should not fail the delete outright — keep polling
+			// until the deadline and surface the last error if the wait times out.
+			tflog.Debug(ctx, fmt.Sprintf("Error reading user %s while waiting for license removal, will retry: %s", userID, err.Error()))
+			return false, err
+		}
+
+		for _, license := range user.GetAssignedLicenses() {
+			if license == nil || license.GetSkuId() == nil {
+				continue
+			}
+			// The API returns SKU ids in canonical lowercase form while the configured
+			// sku_id may use any casing, so compare case-insensitively.
+			if strings.EqualFold(license.GetSkuId().String(), skuID) {
+				tflog.Debug(ctx, fmt.Sprintf("License %s still assigned to user %s, waiting %s before re-checking", skuID, userID, pollInterval))
+				return false, fmt.Errorf("license %s is still assigned to user %s", skuID, userID)
+			}
+		}
+		return true, nil
+	})
 }

--- a/internal/services/resources/users/graph_beta/license_assignment/predicate.go
+++ b/internal/services/resources/users/graph_beta/license_assignment/predicate.go
@@ -2,8 +2,10 @@ package graphBetaUserLicenseAssignment
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // licenseAssignmentConsistencyPredicate returns a consistency predicate for ReadWithRetry that
@@ -22,16 +24,23 @@ import (
 //   - id must be non-empty — confirms the composite userId_skuId key resolved correctly.
 //   - user_id must match — confirms the read is for the correct user object.
 //   - sku_id must match — confirms the correct license SKU is tracked in state.
-//   - disabled_plans count must match — when the SKU is not yet visible in assignedLicenses
-//     on the responding replica, MapRemoteResourceStateToTerraform defaults disabled_plans
-//     to an empty set regardless of what was written. A count mismatch is the primary signal
-//     that the assignedLicenses list has not yet converged on the responding replica.
+//   - the state must not be null — Read removes the resource from state when the managed SKU
+//     is absent from the user's assignedLicenses, so a null state means the assignment has
+//     not been observed on the responding replica yet.
+//   - disabled_plans must match as a set — confirms the disabled plans visible on the
+//     responding replica are exactly the ones that were written, not stale pre-write data.
 //
 // Retries continue until all conditions are satisfied or the context deadline is reached,
 // implementing the polling pattern recommended by Microsoft for Entra eventual consistency:
 // https://devblogs.microsoft.com/identity/designing-for-eventual-consistency-for-microsoft-entra/
 func licenseAssignmentConsistencyPredicate(expected *UserLicenseAssignmentResourceModel) func(ctx context.Context, state tfsdk.State) bool {
 	return func(ctx context.Context, state tfsdk.State) bool {
+		// Read removes the resource from state when the managed SKU is not present in the
+		// user's assignedLicenses. Treat that as "write not yet confirmed" and keep polling.
+		if state.Raw.IsNull() {
+			return false
+		}
+
 		var actual UserLicenseAssignmentResourceModel
 		if diags := state.Get(ctx, &actual); diags.HasError() {
 			return false
@@ -58,13 +67,38 @@ func licenseAssignmentConsistencyPredicate(expected *UserLicenseAssignmentResour
 			return false
 		}
 
-		// disabled_plans count must match the written value. When the SKU is not yet visible
-		// in assignedLicenses on the responding replica, MapRemoteResourceStateToTerraform
-		// defaults disabled_plans to an empty set regardless of what was written.
-		expectedCount := len(expected.DisabledPlans.Elements())
-		if actual.DisabledPlans.IsNull() || actual.DisabledPlans.IsUnknown() {
-			return expectedCount == 0
-		}
-		return len(actual.DisabledPlans.Elements()) == expectedCount
+		// disabled_plans must match the written value as a set, so that stale pre-write
+		// data with the same cardinality but different plan IDs is not accepted.
+		return uuidSetsEqual(expected.DisabledPlans, actual.DisabledPlans)
 	}
+}
+
+// uuidSetsEqual compares two types.Set values of UUID strings for set equality, treating
+// null/unknown as the empty set. UUIDs are compared case-insensitively: the API returns
+// them in canonical lowercase form while the configured values may use any casing.
+func uuidSetsEqual(a, b types.Set) bool {
+	aElems := setElementsAsLowercaseStrings(a)
+	bElems := setElementsAsLowercaseStrings(b)
+	if len(aElems) != len(bElems) {
+		return false
+	}
+	for elem := range aElems {
+		if !bElems[elem] {
+			return false
+		}
+	}
+	return true
+}
+
+func setElementsAsLowercaseStrings(s types.Set) map[string]bool {
+	result := make(map[string]bool)
+	if s.IsNull() || s.IsUnknown() {
+		return result
+	}
+	for _, elem := range s.Elements() {
+		if strVal, ok := elem.(types.String); ok {
+			result[strings.ToLower(strVal.ValueString())] = true
+		}
+	}
+	return result
 }

--- a/internal/services/resources/users/graph_beta/license_assignment/state.go
+++ b/internal/services/resources/users/graph_beta/license_assignment/state.go
@@ -3,6 +3,7 @@ package graphBetaUserLicenseAssignment
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 	"github.com/google/uuid"
@@ -21,10 +22,13 @@ func uuidPointerToStringValue(uuidPtr *uuid.UUID) types.String {
 }
 
 // MapRemoteResourceStateToTerraform maps the properties of a User to Terraform state for license assignment.
-func MapRemoteResourceStateToTerraform(ctx context.Context, data *UserLicenseAssignmentResourceModel, remoteResource graphmodels.Userable) {
+// It returns true when the managed SKU is present in the user's assignedLicenses, and false when
+// the user exists but the license assignment does not — callers use this to distinguish
+// "user found" from "license assignment found".
+func MapRemoteResourceStateToTerraform(ctx context.Context, data *UserLicenseAssignmentResourceModel, remoteResource graphmodels.Userable) bool {
 	if remoteResource == nil {
 		tflog.Debug(ctx, "Remote resource is nil")
-		return
+		return false
 	}
 
 	tflog.Debug(ctx, "Starting to map remote state to Terraform state", map[string]any{
@@ -43,13 +47,17 @@ func MapRemoteResourceStateToTerraform(ctx context.Context, data *UserLicenseAss
 	// propagation delay) we don't leave stale disabled-plan data in state.
 	data.DisabledPlans = types.SetValueMust(types.StringType, []attr.Value{})
 
+	skuFound := false
 	for _, license := range assignedLicenses {
 		if license == nil {
 			continue
 		}
 
 		licenseSkuId := uuidPointerToStringValue(license.GetSkuId())
-		if licenseSkuId.ValueString() == managedSkuId {
+		// The API returns SKU ids in canonical lowercase form while the configured
+		// sku_id may use any casing, so compare case-insensitively.
+		if strings.EqualFold(licenseSkuId.ValueString(), managedSkuId) {
+			skuFound = true
 			disabledPlans := license.GetDisabledPlans()
 			disabledPlanValues := make([]attr.Value, 0, len(disabledPlans))
 			for _, planUUID := range disabledPlans {
@@ -60,5 +68,7 @@ func MapRemoteResourceStateToTerraform(ctx context.Context, data *UserLicenseAss
 		}
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished mapping user license assignment resource with id %s", data.ID.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("Finished mapping user license assignment resource with id %s (sku found: %t)", data.ID.ValueString(), skuFound))
+
+	return skuFound
 }


### PR DESCRIPTION
# Pull Request Description

## Summary

`microsoft365_graph_beta_groups_license_assignment` and its user counterpart `microsoft365_graph_beta_users_user_license_assignment` could report success for license operations that never actually took effect, and `Delete` removed the resource from Terraform state before the license was actually removed. This makes silently failed removals unrecoverable via Terraform and breaks dependent operations, most visibly:

```
Error: Deleting Group (Group: "...")
unexpected status 400 (400 Bad Request) with error: Request_BadRequest: A
group with active licenses assigned cannot be deleted.
```

Root causes:

1. **`POST /groups/{id}/assignLicense` is asynchronous.** It returns `202 Accepted` and the actual add/remove is processed later by the backend licensing service, and can fail after acceptance (e.g. when a removed SKU contains service plans that other assigned SKUs depend on). `Delete` returned success on the `202` and removed the resource from state immediately, so:
   - a dependent `azuread_group` destroy in the same apply raced the removal processing and failed with the error above, and
   - if the removal failed asynchronously, a retry apply never re-attempted it — the resource was already gone from state, leaving the group permanently undeletable via Terraform.
2. **The post-write consistency check never verified the SKU was actually assigned.** The `ReadWithRetry` predicate compared config-derived values against themselves; with `disabled_plans = []` (the common case) it passed even when the SKU was completely absent from `assignedLicenses`. Silently lost license assignments were reported as successful creates.
3. **Concurrent `assignLicense` POSTs against the same group can silently lose updates.** Each call rewrites the group's whole license set asynchronously, and Terraform applies multiple `license_assignment` resources for the same group in parallel by default. There is no official documentation of the concurrency semantics; lost adds/removes were observed in the field.

Changes (group resource first, mirrored onto the user resource, then hardened after live service-principal verification):

- **Serialize `Create`/`Update`/`Delete` per target object** (`sync.Map` of per-group / per-user mutexes), holding the lock until the change is confirmed by read-back. Locks are acquired before the operation timeout starts so queueing does not consume the operation's own budget; waits over 1s are logged.
- **`Delete` now polls `assignedLicenses`** (shared `crud.PollUntil` helper, 5s interval, bounded by the delete timeout) until the SKU is confirmed gone before removing the resource from state. Removal must be observed absent on two consecutive reads to reduce stale-replica false positives; the target object returning 404 is also treated as complete. On timeout the resource is **kept in state** with an actionable error so the removal can be retried; permanent errors (401/403/400 etc.) fail fast.
- **`Read` treats a missing managed SKU as a potentially stale read first**, polling until the read timeout before removing the resource from state. This prevents a lagging replica from making Terraform forget a live license assignment and later trying to delete a still-licensed group.
- **The consistency predicate now requires a non-null state and full set-equality of `disabled_plans`** (previously only the element count was compared, which accepted stale data of the same cardinality).
- **SKU ids and disabled plan ids are compared case-insensitively** to close the schema-validation/API-canonical-form gap.

References documented in code comments:

- [group: assignLicense — returns `202 Accepted`, processed asynchronously](https://learn.microsoft.com/en-us/graph/api/group-assignlicense?view=graph-rest-beta)
- [Group license processing takes time to complete and can fail after acceptance](https://learn.microsoft.com/en-us/entra/identity/users/licensing-group-advanced)
- [A group with licenses cannot be deleted until removal processing completes](https://learn.microsoft.com/en-us/entra/fundamentals/licensing-groups-resolve-problems)
- [Removals can fail when removed SKUs contain service plans other SKUs depend on](https://learn.microsoft.com/en-us/answers/questions/2006508/how-to-remove-multiple-licenses-from-a-security-gr)
- [Microsoft's eventual-consistency guidance for Entra](https://devblogs.microsoft.com/identity/designing-for-eventual-consistency-for-microsoft-entra/)

### Issue Reference

N/A

### Motivation and Context

- Without read-back verification, an asynchronously failed `assignLicense` is indistinguishable from success: Terraform state claims the license is assigned/removed while the tenant disagrees, with no drift detection to ever correct it.
- Once `Delete` has removed the resource from state, a failed removal can never be retried through Terraform — the group becomes undeletable until an operator removes the licenses manually in the Entra portal.
- Multiple `license_assignment` resources targeting the same group is the normal usage pattern of this resource (one resource per SKU by design), so the parallel-apply race is hit by ordinary configurations.

### Dependencies

- No new module dependencies. Adds a shared `crud.PollUntil` helper to `internal/services/common/crud` (used by both resources' `Delete`).
- No schema changes, no breaking configuration changes.
- Behavior change: `Delete` can now return an error (keeping the resource in state) when the license removal does not complete within the delete timeout, instead of always reporting success. This is intentional — the previous behavior is what made failed removals unrecoverable.

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this exact Terraform resource with a local provider build against a real Microsoft 365 tenant

### Unit Tests

```shell
go test -vet=off -p 2 -timeout 240s ./internal/services/resources/groups/graph_beta/license_assignment ./internal/services/resources/users/graph_beta/license_assignment ./internal/services/common/crud

ok  	github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/resources/groups/graph_beta/license_assignment	46.076s
ok  	github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/resources/users/graph_beta/license_assignment	36.411s
ok  	github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/crud	(cached)
```

### Terraform Verification HCL

Executed against a real Microsoft 365 tenant using Azure CLI authentication as the service principal application itself. The access token used by the provider had Microsoft Graph application roles including `Group.ReadWrite.All`, `LicenseAssignment.ReadWrite.All`, `Directory.ReadWrite.All`, and the related read permissions required by these resources.

Available tenant SKUs at verification time:

~~~json
[
  {
    "skuPartNumber": "Microsoft_Entra_Suite",
    "skuId": "f9602137-2203-447b-9fff-41b36e08ce5d",
    "prepaidUnits.enabled": 25,
    "consumedUnits": 1
  },
  {
    "skuPartNumber": "Microsoft_365_ Business_ Premium_(no Teams)",
    "skuId": "00e1ec7b-e4a3-40d1-9441-b69b597ab222",
    "prepaidUnits.enabled": 1,
    "consumedUnits": 1
  }
]
~~~

The live test used an empty security group and two group license-assignment resources targeting that same group:

~~~hcl
provider "microsoft365" {
  tenant_id   = var.tenant_id
  auth_method = "azure_cli"
  cloud       = "public"
}

locals {
  sku_ids = {
    entra_suite      = "f9602137-2203-447b-9fff-41b36e08ce5d"
    business_premium = "00e1ec7b-e4a3-40d1-9441-b69b597ab222"
  }
}

resource "microsoft365_graph_beta_groups_group" "target" {
  display_name     = "codex-pr3264-license-${var.run_id}"
  mail_nickname    = "codexpr3264${var.run_id}"
  mail_enabled     = false
  security_enabled = true
  description      = "Temporary verification group for terraform-provider-microsoft365 PR #3264"
  hard_delete      = true

  timeouts = {
    create = "180s"
    read   = "180s"
    update = "180s"
    delete = "180s"
  }
}

resource "microsoft365_graph_beta_groups_license_assignment" "target" {
  for_each = local.sku_ids

  group_id = microsoft365_graph_beta_groups_group.target.id
  sku_id   = each.value

  timeouts = {
    create = "180s"
    read   = "180s"
    update = "180s"
    delete = "180s"
  }
}
~~~

### Terraform Plan / Apply / Destroy Results

#### Reproduction on origin/main (base commit `07443c187`)

Using a provider binary built from `origin/main` and Azure CLI authenticated as the service principal application, I reproduced the unrecoverable state problem.

The group was created first and allowed to become visible in Graph. Then both license assignments were applied. Terraform reported both license-assignment resources destroyed after 1s, removed them from state, and proceeded to delete the group. The group delete then failed because Graph still had an active license on the group.

Relevant destroy log:

~~~text
microsoft365_graph_beta_groups_license_assignment.target["entra_suite"]: Destruction complete after 1s
microsoft365_graph_beta_groups_license_assignment.target["business_premium"]: Destruction complete after 1s
microsoft365_graph_beta_groups_group.target: Still destroying... [02m30s elapsed]

Error: Delete Failed

Cannot delete group 40933fc5-9b30-4a84-ad0a-4ee93c70c8e2: group still has 1
active license(s) assigned. Please remove all licenses before deleting the
group.
~~~

State after the failed destroy showed the problematic unrecoverable shape: the group remained, but both license-assignment resources were already gone from state.

~~~text
microsoft365_graph_beta_groups_group.target
~~~

Graph after the failed destroy showed the active license still assigned:

~~~json
{
  "id": "40933fc5-9b30-4a84-ad0a-4ee93c70c8e2",
  "displayName": "codex-pr3264-license-20260710104440",
  "assignedLicenses": [
    {
      "disabledPlans": [],
      "skuId": "00e1ec7b-e4a3-40d1-9441-b69b597ab222"
    }
  ]
}
~~~

#### Fixed behavior on this PR (verified at commit `f643ba3c`; current head `affadce2`)

The same service-principal Azure CLI verification was rerun with this PR after strengthening normal `Read` and delete-side removal confirmation.

License assignment apply:

~~~text
microsoft365_graph_beta_groups_license_assignment.target["entra_suite"]: Creation complete after 8s
microsoft365_graph_beta_groups_license_assignment.target["business_premium"]: Still creating... [00m10s elapsed]
microsoft365_graph_beta_groups_license_assignment.target["business_premium"]: Creation complete after 15s
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
~~~

Post-apply plan stayed clean; this specifically verifies that normal `Read` no longer drops the license-assignment resources from state on a stale missing-SKU read.

~~~text
No changes. Your infrastructure matches the configuration.
~~~

Destroy waited for license removals before deleting the group:

~~~text
microsoft365_graph_beta_groups_license_assignment.target["entra_suite"]: Still destroying... [00m10s elapsed]
microsoft365_graph_beta_groups_license_assignment.target["business_premium"]: Still destroying... [00m10s elapsed]
microsoft365_graph_beta_groups_license_assignment.target["entra_suite"]: Destruction complete after 17s
microsoft365_graph_beta_groups_license_assignment.target["business_premium"]: Destruction complete after 24s
microsoft365_graph_beta_groups_group.target: Destroying... [id=654f2781-0996-46a7-b561-7d6574c31d75]
microsoft365_graph_beta_groups_group.target: Still destroying... [00m10s elapsed]
microsoft365_graph_beta_groups_group.target: Destruction complete after 20s
Destroy complete! Resources: 3 destroyed.
~~~

State after destroy was empty and Graph confirmed the group was gone:

~~~text
ERROR: Not Found({"error":{"code":"Request_ResourceNotFound","message":"Resource '654f2781-0996-46a7-b561-7d6574c31d75' does not exist or one of its queried reference-property objects are not present." ... }})
~~~

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

N/A

## Additional Notes

- The fix is organized as group-resource verification, user-resource parity, and a final hardening pass based on live service-principal tenant verification.
- The per-object mutex only serializes operations within a single provider process; it is a defensive measure against the observed lost-update behavior of overlapping `assignLicense` calls, whose concurrency semantics Microsoft does not document.
- `waitForLicenseRemoval` treats a 404 on the target object as successful removal, keeps polling on transient errors, confirms SKU absence on two consecutive reads, and fails fast on permanent errors.
- Normal `Read` no longer removes state on a single missing-SKU read; it first polls for SKU presence up to the read timeout to avoid stale-replica drift. The current head also maps state from the same response that confirmed SKU presence, avoiding a second stale replica read before state is preserved.



