### PR TITLE
fix(settings_catalog_template_json): read assignments from /assignmen…

### DIFF
--- a/internal/services/resources/device_management/graph_beta/settings_catalog_template_json/crud.go
+++ b/internal/services/resources/device_management/graph_beta/settings_catalog_template_json/crud.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/microsoftgraph/msgraph-beta-sdk-go/models"
+
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/crud"
 	customrequest "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/custom_requests"
@@ -12,11 +17,6 @@ import (
 	identitymodels "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/shared_models/graph_beta"
 	sharedmodels "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/shared_models/graph_beta/device_management"
 	sharedstater "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/state/graph_beta/device_management"
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/devicemanagement"
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/models"
 )
 
 // Create handles the Create operation for Device Management Template resources.
@@ -33,7 +33,11 @@ import (
 // The function ensures that both the Device Management Template  and its assignments
 // (if specified) are created properly. The settings must be defined during creation
 // as they are required for a successful deployment, while assignments are optional.
-func (r *DeviceManagementTemplateJsonResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *DeviceManagementTemplateJsonResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	var plan sharedmodels.SettingsCatalogJsonResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("Starting creation of resource: %s", ResourceName))
@@ -43,7 +47,12 @@ func (r *DeviceManagementTemplateJsonResource) Create(ctx context.Context, req r
 		return
 	}
 
-	ctx, cancel := crud.HandleTimeout(ctx, plan.Timeouts.Create, CreateTimeout*time.Second, &resp.Diagnostics)
+	ctx, cancel := crud.HandleTimeout(
+		ctx,
+		plan.Timeouts.Create,
+		CreateTimeout*time.Second,
+		&resp.Diagnostics,
+	)
 	if cancel == nil {
 		return
 	}
@@ -62,9 +71,14 @@ func (r *DeviceManagementTemplateJsonResource) Create(ctx context.Context, req r
 		DeviceManagement().
 		ConfigurationPolicies().
 		Post(ctx, requestBody, nil)
-
 	if err != nil {
-		errors.HandleKiotaGraphError(ctx, err, resp, constants.TfOperationCreate, r.WritePermissions)
+		errors.HandleKiotaGraphError(
+			ctx,
+			err,
+			resp,
+			constants.TfOperationCreate,
+			r.WritePermissions,
+		)
 		return
 	}
 
@@ -85,9 +99,14 @@ func (r *DeviceManagementTemplateJsonResource) Create(ctx context.Context, req r
 		ByDeviceManagementConfigurationPolicyId(plan.ID.ValueString()).
 		Assign().
 		Post(ctx, requestAssignment, nil)
-
 	if err != nil {
-		errors.HandleKiotaGraphError(ctx, err, resp, constants.TfOperationUpdate, r.WritePermissions)
+		errors.HandleKiotaGraphError(
+			ctx,
+			err,
+			resp,
+			constants.TfOperationUpdate,
+			r.WritePermissions,
+		)
 		return
 	}
 
@@ -128,7 +147,11 @@ func (r *DeviceManagementTemplateJsonResource) Create(ctx context.Context, req r
 // The function ensures that all components (base resource, settings, and assignments)
 // are properly read and mapped into the Terraform state, providing a complete view
 // of the resource's current configuration on the server.
-func (r *DeviceManagementTemplateJsonResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *DeviceManagementTemplateJsonResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	var object sharedmodels.SettingsCatalogJsonResourceModel
 	var baseResource models.DeviceManagementConfigurationPolicyable
 	var identity identitymodels.ResourceIdentity
@@ -148,7 +171,12 @@ func (r *DeviceManagementTemplateJsonResource) Read(ctx context.Context, req res
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading %s with ID: %s", ResourceName, object.ID.ValueString()))
 
-	ctx, cancel := crud.HandleTimeout(ctx, object.Timeouts.Read, ReadTimeout*time.Second, &resp.Diagnostics)
+	ctx, cancel := crud.HandleTimeout(
+		ctx,
+		object.Timeouts.Read,
+		ReadTimeout*time.Second,
+		&resp.Diagnostics,
+	)
 	if cancel == nil {
 		return
 	}
@@ -167,12 +195,7 @@ func (r *DeviceManagementTemplateJsonResource) Read(ctx context.Context, req res
 		DeviceManagement().
 		ConfigurationPolicies().
 		ByDeviceManagementConfigurationPolicyId(object.ID.ValueString()).
-		Get(ctx, &devicemanagement.ConfigurationPoliciesDeviceManagementConfigurationPolicyItemRequestBuilderGetRequestConfiguration{
-			QueryParameters: &devicemanagement.ConfigurationPoliciesDeviceManagementConfigurationPolicyItemRequestBuilderGetQueryParameters{
-				Expand: []string{"assignments"},
-			},
-		})
-
+		Get(ctx, nil)
 	if err != nil {
 		errors.HandleKiotaGraphError(ctx, err, resp, operation, r.ReadPermissions)
 		return
@@ -198,13 +221,27 @@ func (r *DeviceManagementTemplateJsonResource) Read(ctx context.Context, req res
 		r.client.GetAdapter(),
 		settingsConfig,
 	)
-
 	if err != nil {
 		errors.HandleKiotaGraphError(ctx, err, resp, operation, r.ReadPermissions)
 		return
 	}
 
 	sharedstater.StateConfigurationPolicySettings(ctx, &object, settingsResponse)
+
+	assignmentsResponse, err := r.client.
+		DeviceManagement().
+		ConfigurationPolicies().
+		ByDeviceManagementConfigurationPolicyId(object.ID.ValueString()).
+		Assignments().
+		Get(ctx, nil)
+	if err != nil {
+		errors.HandleKiotaGraphError(ctx, err, resp, operation, r.ReadPermissions)
+		return
+	}
+
+	if assignmentsResponse != nil {
+		MapAssignmentsToTerraform(ctx, &object, assignmentsResponse.GetValue())
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &object)...)
 	if resp.Diagnostics.HasError() {
@@ -227,7 +264,11 @@ func (r *DeviceManagementTemplateJsonResource) Read(ctx context.Context, req res
 //
 // The function ensures that both the settings and assignments are updated atomically,
 // and the final state reflects the actual state of the resource on the server.
-func (r *DeviceManagementTemplateJsonResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *DeviceManagementTemplateJsonResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	var plan sharedmodels.SettingsCatalogJsonResourceModel
 	var state sharedmodels.SettingsCatalogJsonResourceModel
 
@@ -239,7 +280,12 @@ func (r *DeviceManagementTemplateJsonResource) Update(ctx context.Context, req r
 		return
 	}
 
-	ctx, cancel := crud.HandleTimeout(ctx, plan.Timeouts.Update, UpdateTimeout*time.Second, &resp.Diagnostics)
+	ctx, cancel := crud.HandleTimeout(
+		ctx,
+		plan.Timeouts.Update,
+		UpdateTimeout*time.Second,
+		&resp.Diagnostics,
+	)
 	if cancel == nil {
 		return
 	}
@@ -265,7 +311,6 @@ func (r *DeviceManagementTemplateJsonResource) Update(ctx context.Context, req r
 		ctx,
 		r.client.GetAdapter(),
 		putRequest)
-
 	if err != nil {
 		errors.HandleKiotaGraphError(ctx, err, resp, constants.TfOperationUpdate, r.ReadPermissions)
 		return
@@ -286,9 +331,14 @@ func (r *DeviceManagementTemplateJsonResource) Update(ctx context.Context, req r
 		ByDeviceManagementConfigurationPolicyId(state.ID.ValueString()).
 		Assign().
 		Post(ctx, requestAssignment, nil)
-
 	if err != nil {
-		errors.HandleKiotaGraphError(ctx, err, resp, constants.TfOperationUpdate, r.WritePermissions)
+		errors.HandleKiotaGraphError(
+			ctx,
+			err,
+			resp,
+			constants.TfOperationUpdate,
+			r.WritePermissions,
+		)
 		return
 	}
 
@@ -308,7 +358,10 @@ func (r *DeviceManagementTemplateJsonResource) Update(ctx context.Context, req r
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished updating %s with ID: %s", ResourceName, state.ID.ValueString()))
+	tflog.Debug(
+		ctx,
+		fmt.Sprintf("Finished updating %s with ID: %s", ResourceName, state.ID.ValueString()),
+	)
 }
 
 // Delete handles the Delete operation for Device Management Template resources.
@@ -319,7 +372,11 @@ func (r *DeviceManagementTemplateJsonResource) Update(ctx context.Context, req r
 //   - Cleans up by removing the resource from Terraform state
 //
 // All assignments and settings associated with the resource are automatically removed as part of the deletion.
-func (r *DeviceManagementTemplateJsonResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *DeviceManagementTemplateJsonResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	var object sharedmodels.SettingsCatalogJsonResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("Starting deletion of resource: %s", ResourceName))
@@ -329,7 +386,12 @@ func (r *DeviceManagementTemplateJsonResource) Delete(ctx context.Context, req r
 		return
 	}
 
-	ctx, cancel := crud.HandleTimeout(ctx, object.Timeouts.Delete, DeleteTimeout*time.Second, &resp.Diagnostics)
+	ctx, cancel := crud.HandleTimeout(
+		ctx,
+		object.Timeouts.Delete,
+		DeleteTimeout*time.Second,
+		&resp.Diagnostics,
+	)
 	if cancel == nil {
 		return
 	}
@@ -340,9 +402,14 @@ func (r *DeviceManagementTemplateJsonResource) Delete(ctx context.Context, req r
 		ConfigurationPolicies().
 		ByDeviceManagementConfigurationPolicyId(object.ID.ValueString()).
 		Delete(ctx, nil)
-
 	if err != nil {
-		errors.HandleKiotaGraphError(ctx, err, resp, constants.TfOperationDelete, r.WritePermissions)
+		errors.HandleKiotaGraphError(
+			ctx,
+			err,
+			resp,
+			constants.TfOperationDelete,
+			r.WritePermissions,
+		)
 		return
 	}
 

--- a/internal/services/resources/device_management/graph_beta/settings_catalog_template_json/state.go
+++ b/internal/services/resources/device_management/graph_beta/settings_catalog_template_json/state.go
@@ -4,16 +4,21 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
-	sharedmodels "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/shared_models/graph_beta/device_management"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	graphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
+	sharedmodels "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/shared_models/graph_beta/device_management"
 )
 
 // MapRemoteResourceStateToTerraform states the base properties of a DeviceManagementTemplateResourceModel to a Terraform state
-func MapRemoteResourceStateToTerraform(ctx context.Context, data *sharedmodels.SettingsCatalogJsonResourceModel, remoteResource graphmodels.DeviceManagementConfigurationPolicyable) {
+func MapRemoteResourceStateToTerraform(
+	ctx context.Context,
+	data *sharedmodels.SettingsCatalogJsonResourceModel,
+	remoteResource graphmodels.DeviceManagementConfigurationPolicyable,
+) {
 	if remoteResource == nil {
 		tflog.Debug(ctx, "Remote resource is nil")
 		return
@@ -28,29 +33,34 @@ func MapRemoteResourceStateToTerraform(ctx context.Context, data *sharedmodels.S
 	data.Description = convert.GraphToFrameworkString(remoteResource.GetDescription())
 	data.IsAssigned = convert.GraphToFrameworkBool(remoteResource.GetIsAssigned())
 	data.CreatedDateTime = convert.GraphToFrameworkTime(remoteResource.GetCreatedDateTime())
-	data.LastModifiedDateTime = convert.GraphToFrameworkTime(remoteResource.GetLastModifiedDateTime())
+	data.LastModifiedDateTime = convert.GraphToFrameworkTime(
+		remoteResource.GetLastModifiedDateTime(),
+	)
 	data.SettingsCount = convert.GraphToFrameworkInt32(remoteResource.GetSettingCount())
-	data.RoleScopeTagIds = convert.GraphToFrameworkStringSet(ctx, remoteResource.GetRoleScopeTagIds())
+	data.RoleScopeTagIds = convert.GraphToFrameworkStringSet(
+		ctx,
+		remoteResource.GetRoleScopeTagIds(),
+	)
 
 	if platforms := remoteResource.GetPlatforms(); platforms != nil {
 		data.Platforms = convert.GraphToFrameworkEnum(platforms)
 	}
 
 	if technologies := remoteResource.GetTechnologies(); technologies != nil {
-		data.Technologies = DeviceManagementConfigurationTechnologiesEnumBitmaskToTypeList(*technologies)
+		data.Technologies = DeviceManagementConfigurationTechnologiesEnumBitmaskToTypeList(
+			*technologies,
+		)
 	}
 
-	assignments := remoteResource.GetAssignments()
-	if len(assignments) == 0 {
-		data.Assignments = types.SetNull(SettingsCatalogConfigurationPolicyAssignmentType())
-	} else {
-		MapAssignmentsToTerraform(ctx, data, assignments)
-	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Finished mapping resource %s with id %s", ResourceName, data.ID.ValueString()))
+	tflog.Debug(
+		ctx,
+		fmt.Sprintf("Finished mapping resource %s with id %s", ResourceName, data.ID.ValueString()),
+	)
 }
 
-func DeviceManagementConfigurationTechnologiesEnumBitmaskToTypeList(technologies graphmodels.DeviceManagementConfigurationTechnologies) types.List {
+func DeviceManagementConfigurationTechnologiesEnumBitmaskToTypeList(
+	technologies graphmodels.DeviceManagementConfigurationTechnologies,
+) types.List {
 	var values []attr.Value
 
 	if technologies&graphmodels.NONE_DEVICEMANAGEMENTCONFIGURATIONTECHNOLOGIES != 0 {


### PR DESCRIPTION
# Pull Request Description

## Summary

Fixes microsoft365_graph_beta_device_management_settings_catalog_template_json writing null into the assignments attribute after create/update, which caused Terraform to abort with Provider produced inconsistent result after Terraform apply.
This was first discovered applying ASR (Attack surface reduction) rules.

### Issue Reference

N/A

### Motivation and Context

The Read method retrieved assignments via the $expand=assignments navigation property on GET /deviceManagement/configurationPolicies/{id}. 
Graph does not populate that expanded collection for configuration policies, so MapRemoteResourceStateToTerraform always saw zero assignments and fell back to types.SetNull(...).

The assignments were in fact created correctly in Intune — only the state write-back was wrong. Terraform then compared the planned assignments set against a null result and failed with the following error:

```
Error: Provider produced inconsistent result after apply

When applying changes to
microsoft365_graph_beta_device_management_settings_catalog_template_json.asr001test,
provider "provider[\"registry.terraform.io/deploymenttheory/microsoft365\"]"
produced an unexpected new value: .assignments: was
cty.SetVal([...{"type":"exclusionGroupAssignmentTarget", ...}, {"type":"allDevicesAssignmentTarget", ...}]),
but now null.
```

This blocked any use of the resource with assignments, since Create and Update both route their final state through Read.

The fix mirrors the pattern already used by the sibling settings_catalog_configuration_policy_json resource, which was unaffected by this bug:

- Read now issues an explicit GET /deviceManagement/configurationPolicies/{id}/assignments and maps the returned collection with MapAssignmentsToTerraform.
- The base resource GET no longer passes $expand=assignments.
- The assignment mapping (and its SetNull fallback) was removed from MapRemoteResourceStateToTerraform, so assignments now have exactly one source of truth.
Because Create and Update both finish via crud.ReadWithRetry(ctx, r.Read, ...), all three paths are covered by this single change.

Verifying this both the Graph API docs and in the calls via dev tools in Intune.
REF: https://learn.microsoft.com/en-us/graph/api/intune-gntgraphservice-deviceandappmanagementassignment-assignments?view=graph-rest-beta

### Dependencies

N/A

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this code in the following browsers/environments: 
Utilizing the same logic in settings_catalog_configuration_policy_json which follow the same API pattern for assignments.

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

N/A - see the error trace in Motivation and Context above.

## Additional Notes

Scope is intentionally minimal as this is intended as a bug fix.
Linting was also done on the files hence the small additional changes.
