### PR TITLE
fix(mobile_app_assignment): omit is_removable for non-required intent

### DIFF
--- a/docs/resources/graph_beta_device_and_app_management_mobile_app_assignment.md
+++ b/docs/resources/graph_beta_device_and_app_management_mobile_app_assignment.md
@@ -536,7 +536,7 @@ Optional:
 
 Optional:
 
-- `is_removable` (Boolean) When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE.
+- `is_removable` (Boolean) When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE. This setting is only supported when `intent` is `required`, and must not be configured for any other intent. When it is omitted, the provider does not send it.
 - `prevent_managed_app_backup` (Boolean) When TRUE, indicates that the app should not be backed up to iCloud. When FALSE, indicates that the app may be backed up to iCloud. By default, this property is set to FALSE.
 - `uninstall_on_device_removal` (Boolean) When TRUE, indicates that the app should be uninstalled when the device is removed from Intune. When FALSE, indicates that the app will not be uninstalled when the device is removed from Intune. By default, this property is set to TRUE.
 - `vpn_configuration_id` (String) This is the unique identifier (Id) of the VPN Configuration to apply to the app.
@@ -547,7 +547,7 @@ Optional:
 
 Optional:
 
-- `is_removable` (Boolean) When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE.
+- `is_removable` (Boolean) When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE. This setting is only supported when `intent` is `required`, and must not be configured for any other intent. When it is omitted, the provider does not send it.
 - `prevent_managed_app_backup` (Boolean) When TRUE, indicates that the app should not be backed up to iCloud. When FALSE, indicates that the app may be backed up to iCloud. By default, this property is set to FALSE.
 - `uninstall_on_device_removal` (Boolean) When TRUE, indicates that the app should be uninstalled when the device is removed from Intune. When FALSE, indicates that the app will not be uninstalled when the device is removed from Intune. By default, this property is set to TRUE.
 - `vpn_configuration_id` (String) This is the unique identifier (Id) of the VPN Configuration to apply to the app.
@@ -558,7 +558,7 @@ Optional:
 
 Optional:
 
-- `is_removable` (Boolean) Whether or not the app can be removed by the user. By default, this property is set to FALSE.
+- `is_removable` (Boolean) Whether or not the app can be removed by the user. By default, this property is set to FALSE. This setting is only supported when `intent` is `required`, and must not be configured for any other intent. When it is omitted, the provider does not send it.
 - `prevent_auto_app_update` (Boolean) When TRUE, indicates that the app should not be automatically updated with the latest version from Apple app store. When FALSE, indicates that the app may be auto updated. By default, this property is set to FALSE.
 - `prevent_managed_app_backup` (Boolean) When TRUE, indicates that the app should not be backed up to iCloud. When FALSE, indicates that the app may be backed up to iCloud. By default, this property is set to FALSE.
 - `uninstall_on_device_removal` (Boolean) Whether or not to uninstall the app when device is removed from Intune. By default, this property is set to FALSE.

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/construct.go
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/construct.go
@@ -52,7 +52,7 @@ func ConstructMobileAppAssignment(ctx context.Context, data MobileAppAssignmentR
 
 	// Set Settings
 	if data.Settings != nil {
-		settings, err := constructMobileAppAssignmentSettings(ctx, data.Settings)
+		settings, err := constructMobileAppAssignmentSettings(ctx, data.Settings, data.Intent.ValueString())
 		if err != nil {
 			return nil, fmt.Errorf("error constructing settings: %v", err)
 		}
@@ -148,7 +148,7 @@ func constructAssignmentTarget(ctx context.Context, data *AssignmentTargetResour
 	return target, nil
 }
 
-func constructMobileAppAssignmentSettings(ctx context.Context, data *MobileAppAssignmentSettingsResourceModel) (graphmodels.MobileAppAssignmentSettingsable, error) {
+func constructMobileAppAssignmentSettings(ctx context.Context, data *MobileAppAssignmentSettingsResourceModel, intent string) (graphmodels.MobileAppAssignmentSettingsable, error) {
 	if data == nil {
 		return nil, nil
 	}
@@ -166,7 +166,7 @@ func constructMobileAppAssignmentSettings(ctx context.Context, data *MobileAppAs
 
 	// Handle iOS Lob App settings
 	if data.IosLob != nil {
-		settings, err := constructIosLobAppAssignmentSettings(data.IosLob)
+		settings, err := constructIosLobAppAssignmentSettings(data.IosLob, intent)
 		if err != nil {
 			return nil, fmt.Errorf("error constructing iOS Lob app assignment settings: %v", err)
 		}
@@ -175,7 +175,7 @@ func constructMobileAppAssignmentSettings(ctx context.Context, data *MobileAppAs
 
 	// Handle iOS Store App settings
 	if data.IosStore != nil {
-		settings, err := constructIosStoreAppAssignmentSettings(data.IosStore)
+		settings, err := constructIosStoreAppAssignmentSettings(data.IosStore, intent)
 		if err != nil {
 			return nil, fmt.Errorf("error constructing iOS Store app assignment settings: %v", err)
 		}
@@ -184,7 +184,7 @@ func constructMobileAppAssignmentSettings(ctx context.Context, data *MobileAppAs
 
 	// Handle iOS VPP App settings
 	if data.IosVpp != nil {
-		settings, err := constructIosVppAppAssignmentSettings(data.IosVpp)
+		settings, err := constructIosVppAppAssignmentSettings(data.IosVpp, intent)
 		if err != nil {
 			return nil, fmt.Errorf("error constructing iOS VPP app assignment settings: %v", err)
 		}
@@ -295,14 +295,19 @@ func constructAndroidManagedStoreAppAssignmentSettings(ctx context.Context, data
 	return settings, nil
 }
 
-func constructIosLobAppAssignmentSettings(data *IosLobAppAssignmentSettingsResourceModel) (*graphmodels.IosLobAppAssignmentSettings, error) {
+func constructIosLobAppAssignmentSettings(data *IosLobAppAssignmentSettingsResourceModel, intent string) (*graphmodels.IosLobAppAssignmentSettings, error) {
 	if data == nil {
 		return nil, fmt.Errorf("iOS Lob App data is required")
 	}
 
 	settings := graphmodels.NewIosLobAppAssignmentSettings()
 
-	convert.FrameworkToGraphBool(data.IsRemovable, settings.SetIsRemovable)
+	// The service only supports isRemovable for required intent and returns HTTP 400
+	// otherwise, so never send it for any other intent. This also covers the case where
+	// intent was unknown at plan time and ModifyPlan could not clear the default.
+	if intent == intentRequired {
+		convert.FrameworkToGraphBool(data.IsRemovable, settings.SetIsRemovable)
+	}
 	convert.FrameworkToGraphBool(data.PreventManagedAppBackup, settings.SetPreventManagedAppBackup)
 	convert.FrameworkToGraphBool(data.UninstallOnDeviceRemoval, settings.SetUninstallOnDeviceRemoval)
 	convert.FrameworkToGraphString(data.VpnConfigurationId, settings.SetVpnConfigurationId)
@@ -310,14 +315,19 @@ func constructIosLobAppAssignmentSettings(data *IosLobAppAssignmentSettingsResou
 	return settings, nil
 }
 
-func constructIosStoreAppAssignmentSettings(data *IosStoreAppAssignmentSettingsResourceModel) (*graphmodels.IosStoreAppAssignmentSettings, error) {
+func constructIosStoreAppAssignmentSettings(data *IosStoreAppAssignmentSettingsResourceModel, intent string) (*graphmodels.IosStoreAppAssignmentSettings, error) {
 	if data == nil {
 		return nil, fmt.Errorf("iOS Store App data is required")
 	}
 
 	settings := graphmodels.NewIosStoreAppAssignmentSettings()
 
-	convert.FrameworkToGraphBool(data.IsRemovable, settings.SetIsRemovable)
+	// The service only supports isRemovable for required intent and returns HTTP 400
+	// otherwise, so never send it for any other intent. This also covers the case where
+	// intent was unknown at plan time and ModifyPlan could not clear the default.
+	if intent == intentRequired {
+		convert.FrameworkToGraphBool(data.IsRemovable, settings.SetIsRemovable)
+	}
 	convert.FrameworkToGraphBool(data.PreventManagedAppBackup, settings.SetPreventManagedAppBackup)
 	convert.FrameworkToGraphBool(data.UninstallOnDeviceRemoval, settings.SetUninstallOnDeviceRemoval)
 	convert.FrameworkToGraphString(data.VpnConfigurationId, settings.SetVpnConfigurationId)
@@ -325,14 +335,19 @@ func constructIosStoreAppAssignmentSettings(data *IosStoreAppAssignmentSettingsR
 	return settings, nil
 }
 
-func constructIosVppAppAssignmentSettings(data *IosVppAppAssignmentSettingsResourceModel) (*graphmodels.IosVppAppAssignmentSettings, error) {
+func constructIosVppAppAssignmentSettings(data *IosVppAppAssignmentSettingsResourceModel, intent string) (*graphmodels.IosVppAppAssignmentSettings, error) {
 	if data == nil {
 		return nil, fmt.Errorf("iOS VPP App data is required")
 	}
 
 	settings := graphmodels.NewIosVppAppAssignmentSettings()
 
-	convert.FrameworkToGraphBool(data.IsRemovable, settings.SetIsRemovable)
+	// The service only supports isRemovable for required intent and returns HTTP 400
+	// otherwise, so never send it for any other intent. This also covers the case where
+	// intent was unknown at plan time and ModifyPlan could not clear the default.
+	if intent == intentRequired {
+		convert.FrameworkToGraphBool(data.IsRemovable, settings.SetIsRemovable)
+	}
 	convert.FrameworkToGraphBool(data.PreventAutoAppUpdate, settings.SetPreventAutoAppUpdate)
 	convert.FrameworkToGraphBool(data.PreventManagedAppBackup, settings.SetPreventManagedAppBackup)
 	convert.FrameworkToGraphBool(data.UninstallOnDeviceRemoval, settings.SetUninstallOnDeviceRemoval)

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/mocks/responders.go
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/mocks/responders.go
@@ -1,0 +1,218 @@
+package mocks
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/mocks"
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/mocks/factories"
+	"github.com/google/uuid"
+	"github.com/jarcoal/httpmock"
+)
+
+// mockState tracks the state of assignments for consistent responses
+var mockState struct {
+	sync.Mutex
+	assignments map[string]map[string]any
+	// requests records every assignment payload received, so tests can assert on what the
+	// provider actually sent rather than only on what ended up in Terraform state.
+	requests []map[string]any
+}
+
+func init() {
+	mockState.assignments = make(map[string]map[string]any)
+
+	// Register a default 404 responder for any unmatched requests
+	httpmock.RegisterNoResponder(httpmock.NewStringResponder(404, `{"error":{"code":"ResourceNotFound","message":"Resource not found"}}`))
+
+	// Register with global registry
+	mocks.GlobalRegistry.Register("mobile_app_assignment", &MobileAppAssignmentMock{})
+}
+
+// MobileAppAssignmentMock provides mock responses for mobile app assignment operations
+type MobileAppAssignmentMock struct{}
+
+// isRemovableRejected mirrors the Intune service behaviour: the service rejects the
+// isRemovable setting for any intent other than "required", responding with
+// HTTP 400 "IsRemovable setting is only supported for Required intent."
+//
+// Returns the service error response when the payload is invalid, or nil when it is accepted.
+func isRemovableRejected(assignment map[string]any) *http.Response {
+	settings, ok := assignment["settings"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	if _, present := settings["isRemovable"]; !present {
+		return nil
+	}
+
+	intent, _ := assignment["intent"].(string)
+	if intent == "required" {
+		return nil
+	}
+
+	return httpmock.NewStringResponse(400,
+		`{"error":{"code":"BadRequest","message":"IsRemovable setting is only supported for Required intent."}}`)
+}
+
+// RegisterMocks registers HTTP mock responses for mobile app assignment operations
+func (m *MobileAppAssignmentMock) RegisterMocks() {
+	mockState.Lock()
+	mockState.assignments = make(map[string]map[string]any)
+	mockState.requests = nil
+	mockState.Unlock()
+
+	// POST /deviceAppManagement/mobileApps/{mobileAppId}/assignments
+	httpmock.RegisterResponder("POST", `=~^https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/[^/]+/assignments$`,
+		func(req *http.Request) (*http.Response, error) {
+			var assignment map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&assignment); err != nil {
+				return httpmock.NewStringResponse(400, `{"error":{"code":"BadRequest","message":"Invalid request body"}}`), nil
+			}
+
+			mockState.Lock()
+			mockState.requests = append(mockState.requests, assignment)
+			mockState.Unlock()
+
+			if errResp := isRemovableRejected(assignment); errResp != nil {
+				return errResp, nil
+			}
+
+			if assignment["id"] == nil {
+				assignment["id"] = uuid.New().String()
+			}
+			assignment["@odata.type"] = "#microsoft.graph.mobileAppAssignment"
+
+			assignmentId := assignment["id"].(string)
+			mockState.Lock()
+			mockState.assignments[assignmentId] = assignment
+			mockState.Unlock()
+
+			return httpmock.NewJsonResponse(201, assignment)
+		})
+
+	// GET /deviceAppManagement/mobileApps/{mobileAppId}/assignments/{assignmentId}
+	httpmock.RegisterResponder("GET", `=~^https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/[^/]+/assignments/[^/?]+(\?.+)?$`,
+		func(req *http.Request) (*http.Response, error) {
+			urlParts := strings.Split(req.URL.Path, "/")
+			assignmentId := urlParts[len(urlParts)-1]
+
+			mockState.Lock()
+			assignment, exists := mockState.assignments[assignmentId]
+			mockState.Unlock()
+
+			if !exists {
+				return httpmock.NewStringResponse(404, `{"error":{"code":"ResourceNotFound","message":"Assignment not found"}}`), nil
+			}
+
+			return httpmock.NewJsonResponse(200, assignment)
+		})
+
+	// GET /deviceAppManagement/mobileApps/{mobileAppId}/assignments
+	httpmock.RegisterResponder("GET", `=~^https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/[^/]+/assignments(\?.+)?$`,
+		func(req *http.Request) (*http.Response, error) {
+			mockState.Lock()
+			defer mockState.Unlock()
+
+			assignments := make([]map[string]any, 0, len(mockState.assignments))
+			for _, assignment := range mockState.assignments {
+				assignments = append(assignments, assignment)
+			}
+
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceAppManagement/mobileApps('00000000-0000-0000-0000-000000000001')/assignments",
+				"value":          assignments,
+			})
+		})
+
+	// PATCH /deviceAppManagement/mobileApps/{mobileAppId}/assignments/{assignmentId}
+	httpmock.RegisterResponder("PATCH", `=~^https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/[^/]+/assignments/[^/]+$`,
+		func(req *http.Request) (*http.Response, error) {
+			urlParts := strings.Split(req.URL.Path, "/")
+			assignmentId := urlParts[len(urlParts)-1]
+
+			mockState.Lock()
+			assignment, exists := mockState.assignments[assignmentId]
+			mockState.Unlock()
+
+			if !exists {
+				return httpmock.NewStringResponse(404, `{"error":{"code":"ResourceNotFound","message":"Assignment not found"}}`), nil
+			}
+
+			var update map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&update); err != nil {
+				return httpmock.NewStringResponse(400, `{"error":{"code":"BadRequest","message":"Invalid request body"}}`), nil
+			}
+
+			merged := make(map[string]any, len(assignment))
+			for k, v := range assignment {
+				merged[k] = v
+			}
+			for k, v := range update {
+				merged[k] = v
+			}
+
+			if errResp := isRemovableRejected(merged); errResp != nil {
+				return errResp, nil
+			}
+
+			mockState.Lock()
+			mockState.assignments[assignmentId] = merged
+			mockState.Unlock()
+
+			return httpmock.NewJsonResponse(200, merged)
+		})
+
+	// DELETE /deviceAppManagement/mobileApps/{mobileAppId}/assignments/{assignmentId}
+	httpmock.RegisterResponder("DELETE", `=~^https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/[^/]+/assignments/[^/]+$`,
+		func(req *http.Request) (*http.Response, error) {
+			urlParts := strings.Split(req.URL.Path, "/")
+			assignmentId := urlParts[len(urlParts)-1]
+
+			mockState.Lock()
+			delete(mockState.assignments, assignmentId)
+			mockState.Unlock()
+
+			return httpmock.NewStringResponse(204, ""), nil
+		})
+}
+
+// CleanupMockState clears all stored assignments from the mock state
+func (m *MobileAppAssignmentMock) CleanupMockState() {
+	mockState.Lock()
+	defer mockState.Unlock()
+
+	for id := range mockState.assignments {
+		delete(mockState.assignments, id)
+	}
+	mockState.requests = nil
+}
+
+// SettingsSent returns the settings object of the most recent assignment request whose
+// settings contain the given block name, and whether such a request was seen. It lets tests
+// assert on the payload the provider actually sent.
+func (m *MobileAppAssignmentMock) SettingsSent(block string) (map[string]any, bool) {
+	mockState.Lock()
+	defer mockState.Unlock()
+
+	for i := len(mockState.requests) - 1; i >= 0; i-- {
+		settings, ok := mockState.requests[i]["settings"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if odataType, ok := settings["@odata.type"].(string); ok && strings.Contains(strings.ToLower(odataType), strings.ToLower(block)) {
+			return settings, true
+		}
+	}
+
+	return nil, false
+}
+
+// RegisterErrorMocks registers HTTP mock responses for error scenarios
+func (m *MobileAppAssignmentMock) RegisterErrorMocks() {
+	httpmock.RegisterResponder("POST", `=~^https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/[^/]+/assignments$`,
+		factories.ErrorResponse(400, "BadRequest", "Error creating mobile app assignment"))
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/modify_plan.go
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/modify_plan.go
@@ -3,15 +3,112 @@ package graphBetaDeviceAndAppManagementAppAssignment
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// ModifyPlan handles plan modification for MacOS PKG apps diff suppression to avoid state inconsistency errors
+// intentRequired is the only install intent for which the Intune service accepts the
+// isRemovable assignment setting. Any other intent is rejected with
+// HTTP 400 "IsRemovable setting is only supported for Required intent."
+const intentRequired = "required"
+
+// appleIsRemovablePaths are the Apple settings blocks carrying an is_removable attribute.
+var appleIsRemovablePaths = []path.Path{
+	path.Root("settings").AtName("ios_lob").AtName("is_removable"),
+	path.Root("settings").AtName("ios_store").AtName("is_removable"),
+	path.Root("settings").AtName("ios_vpp").AtName("is_removable"),
+}
+
+// ModifyPlan reconciles the is_removable assignment setting with the install intent.
+//
+// The ios_lob, ios_store and ios_vpp is_removable attributes are Optional+Computed with a
+// static default, so the framework materialises a value into the plan even when the
+// practitioner omits the attribute entirely. That value is then sent to Graph on every
+// request, and the service rejects it for any non-required intent, making it impossible to
+// create an assignment for an Apple app with any other intent.
+//
+// Three cases are handled:
+//
+//   - intent is known and "required": the plan is left untouched, preserving the existing
+//     default behaviour exactly.
+//   - intent is known and not "required": a defaulted value is nulled, so the null-skipping
+//     converters in construct.go omit the field. An explicitly configured value is an error;
+//     ValidateConfig normally catches it first, but cannot when intent was unknown then.
+//   - intent is unknown: a defaulted value is marked unknown. Terraform requires a value that
+//     is known in the initial plan to be identical in the final plan, so leaving the default
+//     known here and nulling it once intent resolves would produce an inconsistent plan.
+//     Planning it as unknown lets the final plan resolve to either the default or null.
+//
+// Attributes are read and written by path rather than by decoding the whole plan, so that a
+// configuration deriving an entire settings or target object from an unknown value is not
+// rejected with a value conversion error.
 func (r *MobileAppAssignmentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+	// Nothing to do when the resource is being destroyed.
+	if req.Plan.Raw.IsNull() {
 		return
 	}
 
-	tflog.Debug(ctx, "Modify Plan Place holder")
+	var intent types.String
+
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("intent"), &intent)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	intentKnown := !intent.IsNull() && !intent.IsUnknown()
+	if intentKnown && intent.ValueString() == intentRequired {
+		return
+	}
+
+	for _, attributePath := range appleIsRemovablePaths {
+		var planned types.Bool
+
+		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, attributePath, &planned)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// A null planned value is already omitted from the request. An unknown one is
+		// resolved on a later plan, once intent is known.
+		if planned.IsNull() || planned.IsUnknown() {
+			continue
+		}
+
+		var configured types.Bool
+
+		resp.Diagnostics.Append(req.Config.GetAttribute(ctx, attributePath, &configured)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Explicitly configured by the practitioner rather than materialised from the
+		// schema default, so it must not be silently discarded.
+		if !configured.IsNull() {
+			if intentKnown {
+				addIsRemovableIntentError(&resp.Diagnostics, attributePath, intent.ValueString())
+				return
+			}
+			continue
+		}
+
+		if !intentKnown {
+			tflog.Debug(ctx, "Planning is_removable as unknown: intent is not yet known")
+
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, attributePath, types.BoolUnknown())...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			continue
+		}
+
+		tflog.Debug(ctx, "Removing is_removable from plan: only supported when intent is 'required'")
+
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, attributePath, types.BoolNull())...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
 }

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/modify_plan.go
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/modify_plan.go
@@ -83,6 +83,13 @@ func (r *MobileAppAssignmentResource) ModifyPlan(ctx context.Context, req resour
 			return
 		}
 
+		// An unknown configured value cannot yet be classified as set or unset, and may
+		// still resolve to null. Leave it for a later plan, matching ValidateConfig, which
+		// also declines to evaluate unknown values.
+		if configured.IsUnknown() {
+			continue
+		}
+
 		// Explicitly configured by the practitioner rather than materialised from the
 		// schema default, so it must not be silently discarded.
 		if !configured.IsNull() {

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/resource.go
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/resource.go
@@ -44,6 +44,9 @@ var (
 	// Enables plan modification/diff suppression
 	_ resource.ResourceWithModifyPlan = &MobileAppAssignmentResource{}
 
+	// Enables config validation before plan
+	_ resource.ResourceWithValidateConfig = &MobileAppAssignmentResource{}
+
 	// Enables identity schema for list resource support
 	_ resource.ResourceWithIdentity = &MobileAppAssignmentResource{}
 
@@ -268,7 +271,7 @@ func (r *MobileAppAssignmentResource) Schema(ctx context.Context, req resource.S
 							"is_removable": schema.BoolAttribute{
 								Optional:            true,
 								Computed:            true,
-								MarkdownDescription: "When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE.",
+								MarkdownDescription: "When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE. This setting is only supported when `intent` is `required`, and must not be configured for any other intent. When it is omitted, the provider does not send it.",
 								Default:             booldefault.StaticBool(true),
 							},
 							"prevent_managed_app_backup": schema.BoolAttribute{
@@ -295,7 +298,7 @@ func (r *MobileAppAssignmentResource) Schema(ctx context.Context, req resource.S
 							"is_removable": schema.BoolAttribute{
 								Optional:            true,
 								Computed:            true,
-								MarkdownDescription: "When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE.",
+								MarkdownDescription: "When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to TRUE. This setting is only supported when `intent` is `required`, and must not be configured for any other intent. When it is omitted, the provider does not send it.",
 								Default:             booldefault.StaticBool(true),
 							},
 							"prevent_managed_app_backup": schema.BoolAttribute{
@@ -322,7 +325,7 @@ func (r *MobileAppAssignmentResource) Schema(ctx context.Context, req resource.S
 							"is_removable": schema.BoolAttribute{
 								Optional:            true,
 								Computed:            true,
-								MarkdownDescription: "Whether or not the app can be removed by the user. By default, this property is set to FALSE.",
+								MarkdownDescription: "Whether or not the app can be removed by the user. By default, this property is set to FALSE. This setting is only supported when `intent` is `required`, and must not be configured for any other intent. When it is omitted, the provider does not send it.",
 								Default:             booldefault.StaticBool(false),
 							},
 							"prevent_auto_app_update": schema.BoolAttribute{

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/resource_test.go
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/resource_test.go
@@ -1,0 +1,306 @@
+package graphBetaDeviceAndAppManagementAppAssignment_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/acceptance/check"
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/helpers"
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/mocks"
+	graphBetaMobileAppAssignment "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment"
+	mobileAppAssignmentMocks "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/mocks"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/jarcoal/httpmock"
+)
+
+const resourceType = graphBetaMobileAppAssignment.ResourceName
+
+// setupMockEnvironment sets up the mock environment using centralized mocks
+func setupMockEnvironment() (*mocks.Mocks, *mobileAppAssignmentMocks.MobileAppAssignmentMock) {
+	// Activate httpmock
+	httpmock.Activate()
+
+	// Create a new Mocks instance and register authentication mocks
+	mockClient := mocks.NewMocks()
+	mockClient.AuthMocks.RegisterMocks()
+
+	// Register local mocks directly
+	assignmentMock := &mobileAppAssignmentMocks.MobileAppAssignmentMock{}
+	assignmentMock.RegisterMocks()
+
+	return mockClient, assignmentMock
+}
+
+// testConfig returns a unit test configuration read from tests/terraform/unit
+func testConfig(t *testing.T, name string) string {
+	t.Helper()
+
+	content, err := helpers.ParseHCLFile(filepath.Join("tests", "terraform", "unit", name))
+	if err != nil {
+		t.Fatalf("failed to read test configuration %s: %v", name, err)
+	}
+	return content
+}
+
+// checkIsRemovableSent asserts whether isRemovable was present in the settings payload the
+// provider actually sent for the given settings block, rather than only in Terraform state.
+func checkIsRemovableSent(t *testing.T, assignmentMock *mobileAppAssignmentMocks.MobileAppAssignmentMock, block string, wantPresent bool, wantValue bool) resource.TestCheckFunc {
+	t.Helper()
+
+	return func(*terraform.State) error {
+		settings, ok := assignmentMock.SettingsSent(block)
+		if !ok {
+			return fmt.Errorf("no assignment request was captured for settings block %s", block)
+		}
+
+		value, present := settings["isRemovable"]
+		if present != wantPresent {
+			return fmt.Errorf("isRemovable present in request = %v, want %v (payload: %v)", present, wantPresent, settings)
+		}
+		if wantPresent && value != wantValue {
+			return fmt.Errorf("isRemovable sent as %v, want %v", value, wantValue)
+		}
+		return nil
+	}
+}
+
+// TestUnitResourceMobileAppAssignment_01_Create_Available_IosVpp verifies that an iOS VPP
+// assignment with intent "available" can be created when is_removable is omitted from the
+// configuration. The Intune service rejects isRemovable for any non-required intent, so the
+// provider must not send the field at all.
+func TestUnitResourceMobileAppAssignment_01_Create_Available_IosVpp(t *testing.T) {
+	_, assignmentMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer assignmentMock.CleanupMockState()
+
+	mocks.SetupUnitTestEnvironment(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(t, "resource_available_ios_vpp.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".available_ios_vpp").Key("id").Exists(),
+					check.That(resourceType+".available_ios_vpp").Key("intent").HasValue("available"),
+					check.That(resourceType+".available_ios_vpp").Key("settings.ios_vpp.use_device_licensing").HasValue("false"),
+					check.That(resourceType+".available_ios_vpp").Key("settings.ios_vpp.is_removable").DoesNotExist(),
+					checkIsRemovableSent(t, assignmentMock, "iosVpp", false, false),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitResourceMobileAppAssignment_02_Create_Available_IosStore verifies the same behaviour
+// for the ios_store settings block.
+func TestUnitResourceMobileAppAssignment_02_Create_Available_IosStore(t *testing.T) {
+	_, assignmentMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer assignmentMock.CleanupMockState()
+
+	mocks.SetupUnitTestEnvironment(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(t, "resource_available_ios_store.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".available_ios_store").Key("id").Exists(),
+					check.That(resourceType+".available_ios_store").Key("intent").HasValue("available"),
+					check.That(resourceType+".available_ios_store").Key("settings.ios_store.is_removable").DoesNotExist(),
+					checkIsRemovableSent(t, assignmentMock, "iosStore", false, false),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitResourceMobileAppAssignment_03_Create_Available_IosLob verifies the same behaviour
+// for the ios_lob settings block.
+func TestUnitResourceMobileAppAssignment_03_Create_Available_IosLob(t *testing.T) {
+	_, assignmentMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer assignmentMock.CleanupMockState()
+
+	mocks.SetupUnitTestEnvironment(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(t, "resource_available_ios_lob.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".available_ios_lob").Key("id").Exists(),
+					check.That(resourceType+".available_ios_lob").Key("intent").HasValue("available"),
+					check.That(resourceType+".available_ios_lob").Key("settings.ios_lob.is_removable").DoesNotExist(),
+					checkIsRemovableSent(t, assignmentMock, "iosLob", false, false),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitResourceMobileAppAssignment_04_Create_Required_IosVpp verifies that explicitly
+// setting is_removable alongside intent "required" continues to work unchanged.
+func TestUnitResourceMobileAppAssignment_04_Create_Required_IosVpp(t *testing.T) {
+	_, assignmentMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer assignmentMock.CleanupMockState()
+
+	mocks.SetupUnitTestEnvironment(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(t, "resource_required_ios_vpp.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".required_ios_vpp").Key("id").Exists(),
+					check.That(resourceType+".required_ios_vpp").Key("intent").HasValue("required"),
+					check.That(resourceType+".required_ios_vpp").Key("settings.ios_vpp.is_removable").HasValue("true"),
+					checkIsRemovableSent(t, assignmentMock, "iosVpp", true, true),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitResourceMobileAppAssignment_05_Create_Required_IsRemovable_Omitted verifies that the
+// static schema default still applies for required intent when the attribute is omitted, so
+// that required-intent behaviour is unchanged.
+func TestUnitResourceMobileAppAssignment_05_Create_Required_IsRemovable_Omitted(t *testing.T) {
+	_, assignmentMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer assignmentMock.CleanupMockState()
+
+	mocks.SetupUnitTestEnvironment(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(t, "resource_required_ios_vpp_omitted.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".required_omitted").Key("intent").HasValue("required"),
+					check.That(resourceType+".required_omitted").Key("settings.ios_vpp.is_removable").HasValue("false"),
+					checkIsRemovableSent(t, assignmentMock, "iosVpp", true, false),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitResourceMobileAppAssignment_06_Create_Uninstall_IosVpp verifies that intents other
+// than "available" which the service also rejects are handled, not just the available case.
+func TestUnitResourceMobileAppAssignment_06_Create_Uninstall_IosVpp(t *testing.T) {
+	_, assignmentMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer assignmentMock.CleanupMockState()
+
+	mocks.SetupUnitTestEnvironment(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(t, "resource_uninstall_ios_vpp.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".uninstall_ios_vpp").Key("intent").HasValue("uninstall"),
+					check.That(resourceType+".uninstall_ios_vpp").Key("settings.ios_vpp.is_removable").DoesNotExist(),
+					checkIsRemovableSent(t, assignmentMock, "iosVpp", false, false),
+				),
+			},
+		},
+	})
+}
+
+// TestUnitResourceMobileAppAssignment_07_Validate_IsRemovable_UnsupportedIntent verifies that
+// explicitly setting is_removable with a non-required intent fails at plan time with a clear
+// message, rather than with an opaque HTTP 400 at apply time. Every Apple settings block is
+// covered, for both boolean values, across each unsupported intent.
+func TestUnitResourceMobileAppAssignment_07_Validate_IsRemovable_UnsupportedIntent(t *testing.T) {
+	testCases := []struct {
+		name   string
+		block  string
+		value  string
+		intent string
+	}{
+		{name: "ios_vpp_true_available", block: "ios_vpp", value: "true", intent: "available"},
+		{name: "ios_vpp_false_available", block: "ios_vpp", value: "false", intent: "available"},
+		{name: "ios_store_true_available", block: "ios_store", value: "true", intent: "available"},
+		{name: "ios_lob_false_uninstall", block: "ios_lob", value: "false", intent: "uninstall"},
+		{name: "ios_vpp_true_available_without_enrollment", block: "ios_vpp", value: "true", intent: "availableWithoutEnrollment"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, assignmentMock := setupMockEnvironment()
+			defer httpmock.DeactivateAndReset()
+			defer assignmentMock.CleanupMockState()
+
+			mocks.SetupUnitTestEnvironment(t)
+
+			config := fmt.Sprintf(`
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "invalid" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = %q
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    %s = {
+      is_removable = %s
+    }
+  }
+}
+`, testCase.intent, testCase.block, testCase.value)
+
+			resource.UnitTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config:      config,
+						ExpectError: regexp.MustCompile(`(?s)is_removable cannot be set when intent is .` + testCase.intent + `.*only supports this setting when intent is .required`),
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestUnitResourceMobileAppAssignment_08_Create_Unknown_Intent verifies the case where intent
+// is not known at plan time, for example when interpolated from another resource. ModifyPlan
+// cannot evaluate the intent then, so the defaulted is_removable must be planned as unknown:
+// Terraform requires a value known in the initial plan to be identical in the final plan, so
+// planning the static default and then nulling it once intent resolves would be rejected with
+// "Provider produced inconsistent final plan".
+func TestUnitResourceMobileAppAssignment_08_Create_Unknown_Intent(t *testing.T) {
+	_, assignmentMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer assignmentMock.CleanupMockState()
+
+	mocks.SetupUnitTestEnvironment(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(t, "resource_unknown_intent.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".unknown_intent").Key("intent").HasValue("available"),
+					check.That(resourceType+".unknown_intent").Key("settings.ios_vpp.is_removable").DoesNotExist(),
+					checkIsRemovableSent(t, assignmentMock, "iosVpp", false, false),
+				),
+			},
+		},
+	})
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_available_ios_lob.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_available_ios_lob.tf
@@ -1,0 +1,16 @@
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "available_ios_lob" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = "available"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    ios_lob = {
+      prevent_managed_app_backup = true
+    }
+  }
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_available_ios_store.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_available_ios_store.tf
@@ -1,0 +1,16 @@
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "available_ios_store" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = "available"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    ios_store = {
+      prevent_managed_app_backup = true
+    }
+  }
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_available_ios_vpp.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_available_ios_vpp.tf
@@ -1,0 +1,16 @@
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "available_ios_vpp" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = "available"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    ios_vpp = {
+      use_device_licensing = false
+    }
+  }
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_required_ios_vpp.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_required_ios_vpp.tf
@@ -1,0 +1,17 @@
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "required_ios_vpp" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = "required"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    ios_vpp = {
+      is_removable         = true
+      use_device_licensing = true
+    }
+  }
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_required_ios_vpp_omitted.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_required_ios_vpp_omitted.tf
@@ -1,0 +1,16 @@
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "required_omitted" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = "required"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    ios_vpp = {
+      use_device_licensing = true
+    }
+  }
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_uninstall_ios_vpp.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_uninstall_ios_vpp.tf
@@ -1,0 +1,16 @@
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "uninstall_ios_vpp" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = "uninstall"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    ios_vpp = {
+      use_device_licensing = false
+    }
+  }
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_unknown_intent.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_unknown_intent.tf
@@ -19,7 +19,9 @@ resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignmen
 
 resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "unknown_intent" {
   mobile_app_id = "00000000-0000-0000-0000-000000000001"
-  intent        = microsoft365_graph_beta_device_and_app_management_mobile_app_assignment.seed.id != "" ? "available" : "available"
+  # Distinct branches, so the expression cannot be folded to a constant. seed.id is a
+  # non-empty generated id, so this always resolves to "available", but only after apply.
+  intent = length(microsoft365_graph_beta_device_and_app_management_mobile_app_assignment.seed.id) > 0 ? "available" : "uninstall"
   source        = "direct"
 
   target = {

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_unknown_intent.tf
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/tests/terraform/unit/resource_unknown_intent.tf
@@ -1,0 +1,35 @@
+# The first assignment supplies a computed attribute so that the second assignment's intent is
+# unknown at plan time, mirroring an intent interpolated from another resource.
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "seed" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = "required"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "22222222-2222-2222-2222-222222222222"
+  }
+
+  settings = {
+    ios_vpp = {
+      use_device_licensing = true
+    }
+  }
+}
+
+resource "microsoft365_graph_beta_device_and_app_management_mobile_app_assignment" "unknown_intent" {
+  mobile_app_id = "00000000-0000-0000-0000-000000000001"
+  intent        = microsoft365_graph_beta_device_and_app_management_mobile_app_assignment.seed.id != "" ? "available" : "available"
+  source        = "direct"
+
+  target = {
+    target_type = "groupAssignment"
+    group_id    = "11111111-1111-1111-1111-111111111111"
+  }
+
+  settings = {
+    ios_vpp = {
+      use_device_licensing = false
+    }
+  }
+}

--- a/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/validate_config.go
+++ b/internal/services/resources/device_and_app_management/graph_beta/mobile_app_assignment/validate_config.go
@@ -1,0 +1,67 @@
+package graphBetaDeviceAndAppManagementAppAssignment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ValidateConfig rejects configurations that explicitly set is_removable on an Apple settings
+// block alongside an install intent other than "required".
+//
+// The Intune service only supports the isRemovable setting for required intent and returns
+// HTTP 400 "IsRemovable setting is only supported for Required intent." otherwise. Reporting
+// it at validation time gives the practitioner an actionable error rather than a failure
+// part-way through an apply.
+//
+// When intent is not yet known this cannot be evaluated; ModifyPlan repeats the check once
+// intent resolves.
+//
+// Attributes are read by path rather than by decoding the whole configuration, so that a
+// configuration deriving an entire settings or target object from an unknown value is not
+// rejected with a value conversion error.
+func (r *MobileAppAssignmentResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var intent types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("intent"), &intent)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if intent.IsNull() || intent.IsUnknown() || intent.ValueString() == intentRequired {
+		return
+	}
+
+	for _, attributePath := range appleIsRemovablePaths {
+		var isRemovable types.Bool
+
+		resp.Diagnostics.Append(req.Config.GetAttribute(ctx, attributePath, &isRemovable)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if isRemovable.IsNull() || isRemovable.IsUnknown() {
+			continue
+		}
+
+		addIsRemovableIntentError(&resp.Diagnostics, attributePath, intent.ValueString())
+	}
+}
+
+// addIsRemovableIntentError appends the diagnostic raised when is_removable is configured
+// alongside an install intent that the service does not support it for.
+func addIsRemovableIntentError(diagnostics *diag.Diagnostics, attributePath path.Path, intent string) {
+	diagnostics.AddAttributeError(
+		attributePath,
+		"Invalid Attribute Combination",
+		fmt.Sprintf(
+			"is_removable cannot be set when intent is %q. The Intune service only supports "+
+				"this setting when intent is %q. Remove the attribute, or change the intent.",
+			intent, intentRequired,
+		),
+	)
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Makes it possible to create assignments that use an `ios_lob`, `ios_store` or `ios_vpp` settings block with an `intent` other than `required`.

The `is_removable` attribute on the `ios_lob`, `ios_store` and `ios_vpp` settings blocks is `Optional + Computed` with a static default, so Terraform materialises a value into the plan even when the practitioner omits the attribute. That value is then serialised into the request whenever one of those blocks is present, and the Intune service rejects `isRemovable` for any non-`required` intent with `HTTP 400 "IsRemovable setting is only supported for Required intent."`, making such assignments impossible to create with any other intent.

This PR nulls the planned value when `intent` is not `required`, so the existing null-skipping converter in `construct.go` omits the field, and adds plan-time validation for the case where a practitioner sets it explicitly.

### Issue Reference

Fixes #3692

### Motivation and Context

Any intent other than `required` is currently unusable for these three settings blocks. This blocks self-service app deployment to user-enrolled (BYOD) devices, where Intune supports a limited set of app types and pushing apps as `required` to a personal device is not appropriate.

The service itself is behaving correctly: it accepts the assignment when `isRemovable` is simply absent. The provider had no way to express "do not send this field": both omitting the attribute and setting it to `null` produced the same 400.

### What changed

- **`modify_plan.go`**: when `intent` is known and not `required`, null the planned `is_removable` for the three Apple settings blocks. `convert.FrameworkToGraphBool` already skips null and unknown values, so the field is simply omitted from the request. Required-intent behaviour, including the existing defaults, is untouched. When `intent` is unknown at plan time, for example interpolated from another resource, the value is planned as **unknown** instead: Terraform requires a value known in the initial plan to be identical in the final plan, so planning the static default and then nulling it once the intent resolves is rejected with `Provider produced inconsistent final plan`. Planning it unknown lets the final plan resolve to either the default or null. An explicitly configured value is never silently discarded; it raises the same error `ValidateConfig` would have, once the intent is known.
- **`construct.go`**: thread the resolved `intent` into the three Apple settings constructors and only call `SetIsRemovable` when it is `required`, as a final invariant at request construction.
- **`validate_config.go`** (new): a `ResourceWithValidateConfig` rule that rejects an explicitly-set `is_removable` alongside a non-required intent at plan time, rather than as a late API error part-way through an apply. It follows the shape of the existing `validateInstallTimeSettings` intent rule in `internal/services/common/validate/graph_beta/device_and_app_management/mobile_app_assignment.go`. I implemented it on the resource rather than adding it there because that package does not appear to be called from anywhere. Please point me at the right home if I have missed something.
- **`resource.go`**: registered the `ValidateConfig` interface and clarified the three `is_removable` descriptions to state the intent restriction.
- **`resource_test.go`, `mocks/responders.go`, `tests/terraform/unit/`** (new): first tests for this resource, following the conventions in `.github/ai-instructions.md`: configs under `tests/terraform/unit/`, mock responders registered with `mocks.GlobalRegistry` and exposing `CleanupMockState()`, `mocks.SetupUnitTestEnvironment(t)`, and fluent `check.That(...)` assertions. The mock responder mirrors the real service rule, so the tests fail on the unmodified provider and pass with the fix.
- **`docs/`**: regenerated descriptions for the three attributes.

`ModifyPlan` reads and writes, and `ValidateConfig` reads, attributes by path rather than decoding the whole plan or config into the nested model structs. Those structs cannot represent a wholly-unknown nested object, so decoding them would reject a configuration that derives an entire `settings` or `target` object from an unknown value.

### Approaches considered

Two alternatives were tried first and rejected on evidence; both are described more fully in the issue.

1. **Deleting the three `Default:` lines.** Smallest diff, but the attribute then plans as *unknown* and nothing ever writes it back, so the apply fails with `Provider returned invalid result object after apply ... still indicated an unknown value`. (Confirmed by test.)
2. **Threading `intent` into the three Apple settings constructors and skipping `SetIsRemovable`.** This does work today, but only because `Read` currently discards the result of `MapRemoteStateToTerraform`: state keeps the planned default while the service holds `null`. On its own it would break with `Provider produced inconsistent result after apply` if that were corrected. It is retained here as a final invariant at request construction, not as the primary mechanism.

The plan-level approach does not depend on the `Read` behaviour. I'm happy to switch to option 1 (combined with a `Read` fix) if you would rather address both together.

### Dependencies

None. No new dependencies, no configuration changes, no version updates.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (targeted package tests; see the note on a pre-existing unrelated panic below)
- [x] I have tested this code in the following browsers/environments: macOS, Go 1.26.5, Terraform 1.x. Unit tests use mocked Graph responses; the underlying API behaviour was also confirmed against a live tenant with raw Graph calls.

Eight tests were added (13 including subtests):

```
--- PASS: TestUnitResourceMobileAppAssignment_01_Create_Available_IosVpp
--- PASS: TestUnitResourceMobileAppAssignment_02_Create_Available_IosStore
--- PASS: TestUnitResourceMobileAppAssignment_03_Create_Available_IosLob
--- PASS: TestUnitResourceMobileAppAssignment_04_Create_Required_IosVpp
--- PASS: TestUnitResourceMobileAppAssignment_05_Create_Required_IsRemovable_Omitted
--- PASS: TestUnitResourceMobileAppAssignment_06_Create_Uninstall_IosVpp
--- PASS: TestUnitResourceMobileAppAssignment_07_Validate_IsRemovable_UnsupportedIntent
    --- PASS: .../ios_vpp_true_available
    --- PASS: .../ios_vpp_false_available
    --- PASS: .../ios_store_true_available
    --- PASS: .../ios_lob_false_uninstall
    --- PASS: .../ios_vpp_true_available_without_enrollment
--- PASS: TestUnitResourceMobileAppAssignment_08_Create_Unknown_Intent
```

Coverage spans available intent for all three Apple blocks, `uninstall`, unchanged required-intent behaviour both with the attribute set and omitted, an `intent` that is unknown at plan time, and the plan-time validation error for every affected block across `available`, `uninstall` and `availableWithoutEnrollment`. The mock records each request body, so the tests assert on the payload the provider actually sent, not only on Terraform state.

All three available-intent tests fail with the 400 on the unmodified provider.

One note on the wider suite: `internal/services/resources/device_and_app_management/graph_beta/windows_managed_app_protection` panics under `go test`, but it does so identically on a clean checkout of `main`, so it is unrelated to this change.

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project. Tests follow `.github/ai-instructions.md`, except that there are no `tests/responses/` JSON fixtures (responses are built in the responder) and no import step, since import is not currently functional for this resource
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [x] I have made corresponding changes to the README and other relevant documentation (the generated resource docs; the README needed no change)
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Additional Notes

One pre-existing detail is worth flagging, because the choice of fix depends on it: `Read` in `crud.go` calls `MapRemoteStateToTerraform(ctx, object, resource)` and discards the return value, even though that function takes the model by value and returns the updated copy. The practical effect is that `Read` does not refresh this resource from the API. I have left it alone to keep this diff focused, since changing it would affect refresh behaviour for existing users, but it is why the approach here works at the plan level rather than relying on state written back after apply. Happy to raise it separately.
