### PR TITLE
feat: support priority and assignment filters on windows enrollment status page

### DIFF
--- a/examples/resources/microsoft365_graph_beta_device_management_windows_enrollment_status_page/resource.tf
+++ b/examples/resources/microsoft365_graph_beta_device_management_windows_enrollment_status_page/resource.tf
@@ -1,4 +1,5 @@
 resource "microsoft365_graph_beta_device_management_windows_enrollment_status_page" "with_assignments" {
+  priority                                                            = 10
   display_name                                                        = "example-windows-enrollment-status-page-with-assignments"
   description                                                         = "Test description for enrollment status page with assignments"
   show_installation_progress                                          = true
@@ -38,8 +39,10 @@ resource "microsoft365_graph_beta_device_management_windows_enrollment_status_pa
       group_id = microsoft365_graph_beta_groups_group.acc_test_group_1.id
     },
     {
-      type     = "groupAssignmentTarget"
-      group_id = microsoft365_graph_beta_groups_group.acc_test_group_2.id
+      type        = "groupAssignmentTarget"
+      group_id    = microsoft365_graph_beta_groups_group.acc_test_group_2.id
+      filter_id   = "00000000-0000-0000-0000-000000000001"
+      filter_type = "include"
     }
   ]
   timeouts = {

--- a/internal/services/common/schema/graph_beta/device_management/device_configuration_assignment.go
+++ b/internal/services/common/schema/graph_beta/device_management/device_configuration_assignment.go
@@ -3,13 +3,14 @@ package schema
 import (
 	"regexp"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
-	customValidator "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/validate/attribute"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
+	customValidator "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/validate/attribute"
 )
 
 // DeviceConfigurationWithAllGroupAssignmentsAndFilterSchema is a schema for device configuration
@@ -54,8 +55,14 @@ func DeviceConfigurationWithAllGroupAssignmentsAndFilterSchema() schema.SetNeste
 							regexp.MustCompile(constants.GuidRegex),
 							"must be a valid GUID in the format 00000000-0000-0000-0000-000000000000",
 						),
-						customValidator.RequiredWhenEquals("filter_type", types.StringValue("include")),
-						customValidator.RequiredWhenEquals("filter_type", types.StringValue("exclude")),
+						customValidator.RequiredWhenEquals(
+							"filter_type",
+							types.StringValue("include"),
+						),
+						customValidator.RequiredWhenEquals(
+							"filter_type",
+							types.StringValue("exclude"),
+						),
 						stringvalidator.NoneOf("00000000-0000-0000-0000-000000000000"),
 					},
 				},
@@ -179,8 +186,14 @@ func DeviceConfigurationWithAllLicensedUsersInclusionGroupAssignmentsAndFilterSc
 							regexp.MustCompile(constants.GuidRegex),
 							"must be a valid GUID in the format 00000000-0000-0000-0000-000000000000",
 						),
-						customValidator.RequiredWhenEquals("filter_type", types.StringValue("include")),
-						customValidator.RequiredWhenEquals("filter_type", types.StringValue("exclude")),
+						customValidator.RequiredWhenEquals(
+							"filter_type",
+							types.StringValue("include"),
+						),
+						customValidator.RequiredWhenEquals(
+							"filter_type",
+							types.StringValue("exclude"),
+						),
 						stringvalidator.NoneOf("00000000-0000-0000-0000-000000000000"),
 					},
 				},
@@ -189,6 +202,66 @@ func DeviceConfigurationWithAllLicensedUsersInclusionGroupAssignmentsAndFilterSc
 					MarkdownDescription: "Type of filter to apply. Must be one of: 'include', 'exclude', or 'none'.",
 					Computed:            true,
 					Default:             stringdefault.StaticString("none"),
+					Validators: []validator.String{
+						stringvalidator.OneOf("include", "exclude", "none"),
+					},
+				},
+			},
+		},
+	}
+}
+
+// DeviceConfigurationWithAllLicensedUsersAllDevicesInclusionGroupAssignmentsAndFilterSchema is a schema for device configuration assignments that supports all devices, all licensed users, and inclusion group targets with group filters.
+func DeviceConfigurationWithAllLicensedUsersAllDevicesInclusionGroupAssignmentsAndFilterSchema() schema.SetNestedAttribute {
+	return schema.SetNestedAttribute{
+		MarkdownDescription: "Assignments for the device configuration. Each assignment specifies the target group and supports group filters.",
+		Optional:            true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"type": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "Type of assignment target. Must be one of: 'allDevicesAssignmentTarget', 'allLicensedUsersAssignmentTarget', or 'groupAssignmentTarget'.",
+					Validators: []validator.String{
+						stringvalidator.OneOf(
+							"allDevicesAssignmentTarget",
+							"allLicensedUsersAssignmentTarget",
+							"groupAssignmentTarget",
+						),
+					},
+				},
+				"group_id": schema.StringAttribute{
+					Optional:            true,
+					MarkdownDescription: "The Entra ID group ID to include in the assignment. Required when type is 'groupAssignmentTarget'.",
+					Validators: []validator.String{
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(constants.GuidRegex),
+							"must be a valid GUID in the format 00000000-0000-0000-0000-000000000000",
+						),
+					},
+				},
+				"filter_id": schema.StringAttribute{
+					Optional:            true,
+					MarkdownDescription: "ID of the filter to apply to the assignment. Required when filter_type is 'include' or 'exclude'. Should be omitted when filter_type is 'none'.",
+					Validators: []validator.String{
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(constants.GuidRegex),
+							"must be a valid GUID in the format 00000000-0000-0000-0000-000000000000",
+						),
+						customValidator.RequiredWhenEquals(
+							"filter_type",
+							types.StringValue("include"),
+						),
+						customValidator.RequiredWhenEquals(
+							"filter_type",
+							types.StringValue("exclude"),
+						),
+					},
+				},
+				"filter_type": schema.StringAttribute{
+					Optional:            true,
+					Computed:            true,
+					Default:             stringdefault.StaticString("none"),
+					MarkdownDescription: "Type of filter to apply. Must be one of: 'include', 'exclude', or 'none'.",
 					Validators: []validator.String{
 						stringvalidator.OneOf("include", "exclude", "none"),
 					},

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/construct.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/construct.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/constructors"
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	msgraphbetasdk "github.com/microsoftgraph/msgraph-beta-sdk-go"
 	graphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/constructors"
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 )
 
 // constructResource constructs a Windows10EnrollmentCompletionPageConfiguration from the Terraform model
-func constructResource(ctx context.Context, client *msgraphbetasdk.GraphServiceClient, plan *WindowsEnrollmentStatusPageResourceModel) (graphmodels.DeviceEnrollmentConfigurationable, error) {
+func constructResource(
+	ctx context.Context,
+	client *msgraphbetasdk.GraphServiceClient,
+	plan *WindowsEnrollmentStatusPageResourceModel,
+) (graphmodels.DeviceEnrollmentConfigurationable, error) {
 	tflog.Debug(ctx, fmt.Sprintf("Constructing %s from plan", ResourceName))
 
 	// Validate the request data
@@ -22,17 +27,42 @@ func constructResource(ctx context.Context, client *msgraphbetasdk.GraphServiceC
 
 	requestBody := graphmodels.NewWindows10EnrollmentCompletionPageConfiguration()
 
+	convert.FrameworkToGraphInt32(plan.Priority, requestBody.SetPriority)
 	convert.FrameworkToGraphString(plan.DisplayName, requestBody.SetDisplayName)
 	convert.FrameworkToGraphString(plan.Description, requestBody.SetDescription)
-	convert.FrameworkToGraphBool(plan.ShowInstallationProgress, requestBody.SetShowInstallationProgress)
-	convert.FrameworkToGraphBool(plan.OnlyShowPageToDevicesProvisionedByOutOfBoxExperienceOobe, requestBody.SetDisableUserStatusTrackingAfterFirstUser) // using custom key name as dev was getting very confusing.
-	convert.FrameworkToGraphBool(plan.AllowDeviceResetOnInstallFailure, requestBody.SetAllowDeviceResetOnInstallFailure)
-	convert.FrameworkToGraphBool(plan.AllowLogCollectionOnInstallFailure, requestBody.SetAllowLogCollectionOnInstallFailure)
+	convert.FrameworkToGraphBool(
+		plan.ShowInstallationProgress,
+		requestBody.SetShowInstallationProgress,
+	)
+	convert.FrameworkToGraphBool(
+		plan.OnlyShowPageToDevicesProvisionedByOutOfBoxExperienceOobe,
+		requestBody.SetDisableUserStatusTrackingAfterFirstUser,
+	) // using custom key name as dev was getting very confusing.
+	convert.FrameworkToGraphBool(
+		plan.AllowDeviceResetOnInstallFailure,
+		requestBody.SetAllowDeviceResetOnInstallFailure,
+	)
+	convert.FrameworkToGraphBool(
+		plan.AllowLogCollectionOnInstallFailure,
+		requestBody.SetAllowLogCollectionOnInstallFailure,
+	)
 	convert.FrameworkToGraphString(plan.CustomErrorMessage, requestBody.SetCustomErrorMessage)
-	convert.FrameworkToGraphInt32(plan.InstallProgressTimeoutInMinutes, requestBody.SetInstallProgressTimeoutInMinutes)
-	convert.FrameworkToGraphBool(plan.AllowDeviceUseOnInstallFailure, requestBody.SetAllowDeviceUseOnInstallFailure)
-	convert.FrameworkToGraphBool(plan.BlockDeviceUseUntilAllAppsAndProfilesAreInstalled, requestBody.SetBlockDeviceSetupRetryByUser) // using custom key name as dev was getting very confusing.
-	convert.FrameworkToGraphBool(plan.OnlyFailSelectedBlockingAppsInTechnicianPhase, requestBody.SetAllowNonBlockingAppInstallation) // using custom key name as dev was getting very confusing.
+	convert.FrameworkToGraphInt32(
+		plan.InstallProgressTimeoutInMinutes,
+		requestBody.SetInstallProgressTimeoutInMinutes,
+	)
+	convert.FrameworkToGraphBool(
+		plan.AllowDeviceUseOnInstallFailure,
+		requestBody.SetAllowDeviceUseOnInstallFailure,
+	)
+	convert.FrameworkToGraphBool(
+		plan.BlockDeviceUseUntilAllAppsAndProfilesAreInstalled,
+		requestBody.SetBlockDeviceSetupRetryByUser,
+	) // using custom key name as dev was getting very confusing.
+	convert.FrameworkToGraphBool(
+		plan.OnlyFailSelectedBlockingAppsInTechnicianPhase,
+		requestBody.SetAllowNonBlockingAppInstallation,
+	) // using custom key name as dev was getting very confusing.
 	convert.FrameworkToGraphBool(plan.InstallQualityUpdates, requestBody.SetInstallQualityUpdates)
 
 	// Set selected_mobile_app_ids to empty array by default so that we can add and remove apps in updates.
@@ -40,16 +70,28 @@ func constructResource(ctx context.Context, client *msgraphbetasdk.GraphServiceC
 	requestBody.SetSelectedMobileAppIds(BlockDeviceUseRequiredAppIds)
 
 	if !plan.SelectedMobileAppIds.IsNull() && !plan.SelectedMobileAppIds.IsUnknown() {
-		if err := convert.FrameworkToGraphStringSet(ctx, plan.SelectedMobileAppIds, requestBody.SetSelectedMobileAppIds); err != nil {
-			return nil, fmt.Errorf("failed to convert selected mobile app IDs: %v", err)
+		if err := convert.FrameworkToGraphStringSet(
+			ctx,
+			plan.SelectedMobileAppIds,
+			requestBody.SetSelectedMobileAppIds,
+		); err != nil {
+			return nil, fmt.Errorf("failed to convert selected mobile app IDs: %w", err)
 		}
 	}
 
-	if err := convert.FrameworkToGraphStringSet(ctx, plan.RoleScopeTagIds, requestBody.SetRoleScopeTagIds); err != nil {
-		return nil, fmt.Errorf("failed to convert role scope tag IDs: %v", err)
+	if err := convert.FrameworkToGraphStringSet(
+		ctx,
+		plan.RoleScopeTagIds,
+		requestBody.SetRoleScopeTagIds,
+	); err != nil {
+		return nil, fmt.Errorf("failed to convert role scope tag IDs: %w", err)
 	}
 
-	if err := constructors.DebugLogGraphObject(ctx, fmt.Sprintf("Final JSON to be sent to Graph API for resource %s", ResourceName), requestBody); err != nil {
+	if err := constructors.DebugLogGraphObject(
+		ctx,
+		fmt.Sprintf("Final JSON to be sent to Graph API for resource %s", ResourceName),
+		requestBody,
+	); err != nil {
 		tflog.Error(ctx, "Failed to debug log object", map[string]any{
 			"error": err.Error(),
 		})

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/construct_assignment.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/construct_assignment.go
@@ -4,16 +4,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/constructors"
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
-	sharedmodels "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/shared_models/graph_beta/device_management"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/devicemanagement"
 	graphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/constructors"
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
+	sharedmodels "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/shared_models/graph_beta/device_management"
 )
 
 // constructAssignment constructs and returns a DeviceEnrollmentConfigurationsItemAssignPostRequestBodyable
-func constructAssignment(ctx context.Context, data *WindowsEnrollmentStatusPageResourceModel) (devicemanagement.DeviceEnrollmentConfigurationsItemAssignPostRequestBodyable, error) {
+func constructAssignment(
+	ctx context.Context,
+	data *WindowsEnrollmentStatusPageResourceModel,
+) (devicemanagement.DeviceEnrollmentConfigurationsItemAssignPostRequestBodyable, error) {
 	tflog.Debug(ctx, "Starting Windows Enrollment Status Page assignment construction")
 
 	requestBody := devicemanagement.NewDeviceEnrollmentConfigurationsItemAssignPostRequestBody()
@@ -25,7 +29,7 @@ func constructAssignment(ctx context.Context, data *WindowsEnrollmentStatusPageR
 		return requestBody, nil
 	}
 
-	var terraformAssignments []sharedmodels.DeviceManagementDeviceConfigurationAssignmentWithoutGroupFilterModel
+	var terraformAssignments []sharedmodels.DeviceManagementDeviceConfigurationAssignmentWithGroupFilterModel
 	diags := data.Assignments.ElementsAs(ctx, &terraformAssignments, false)
 	if diags.HasError() {
 		return nil, fmt.Errorf("failed to extract assignments: %v", diags.Errors())
@@ -66,7 +70,11 @@ func constructAssignment(ctx context.Context, data *WindowsEnrollmentStatusPageR
 
 	requestBody.SetEnrollmentConfigurationAssignments(enrollmentAssignments)
 
-	if err := constructors.DebugLogGraphObject(ctx, "Constructed assignment request body", requestBody); err != nil {
+	if err := constructors.DebugLogGraphObject(
+		ctx,
+		"Constructed assignment request body",
+		requestBody,
+	); err != nil {
 		tflog.Error(ctx, "Failed to debug log assignment request body", map[string]any{
 			"error": err.Error(),
 		})
@@ -76,7 +84,11 @@ func constructAssignment(ctx context.Context, data *WindowsEnrollmentStatusPageR
 }
 
 // constructTarget creates the appropriate target based on the target type
-func constructTarget(ctx context.Context, targetType string, assignment sharedmodels.DeviceManagementDeviceConfigurationAssignmentWithoutGroupFilterModel) graphmodels.DeviceAndAppManagementAssignmentTargetable {
+func constructTarget(
+	ctx context.Context,
+	targetType string,
+	assignment sharedmodels.DeviceManagementDeviceConfigurationAssignmentWithGroupFilterModel,
+) graphmodels.DeviceAndAppManagementAssignmentTargetable {
 	var target graphmodels.DeviceAndAppManagementAssignmentTargetable
 
 	switch targetType {
@@ -86,7 +98,8 @@ func constructTarget(ctx context.Context, targetType string, assignment sharedmo
 		target = graphmodels.NewAllLicensedUsersAssignmentTarget()
 	case "groupAssignmentTarget":
 		groupTarget := graphmodels.NewGroupAssignmentTarget()
-		if !assignment.GroupId.IsNull() && !assignment.GroupId.IsUnknown() && assignment.GroupId.ValueString() != "" {
+		if !assignment.GroupId.IsNull() && !assignment.GroupId.IsUnknown() &&
+			assignment.GroupId.ValueString() != "" {
 			convert.FrameworkToGraphString(assignment.GroupId, groupTarget.SetGroupId)
 		} else {
 			tflog.Error(ctx, "Group assignment target missing required group_id", map[string]any{
@@ -100,6 +113,30 @@ func constructTarget(ctx context.Context, targetType string, assignment sharedmo
 			"targetType": targetType,
 		})
 		return nil
+	}
+
+	if !assignment.FilterId.IsNull() && !assignment.FilterId.IsUnknown() &&
+		assignment.FilterId.ValueString() != "" {
+		convert.FrameworkToGraphString(
+			assignment.FilterId,
+			target.SetDeviceAndAppManagementAssignmentFilterId,
+		)
+	}
+
+	if !assignment.FilterType.IsNull() && !assignment.FilterType.IsUnknown() {
+		filterType := assignment.FilterType.ValueString()
+		var filterTypeEnum graphmodels.DeviceAndAppManagementAssignmentFilterType
+		switch filterType {
+		case "include":
+			filterTypeEnum = graphmodels.INCLUDE_DEVICEANDAPPMANAGEMENTASSIGNMENTFILTERTYPE
+		case "exclude":
+			filterTypeEnum = graphmodels.EXCLUDE_DEVICEANDAPPMANAGEMENTASSIGNMENTFILTERTYPE
+		case "none":
+			filterTypeEnum = graphmodels.NONE_DEVICEANDAPPMANAGEMENTASSIGNMENTFILTERTYPE
+		default:
+			return target
+		}
+		target.SetDeviceAndAppManagementAssignmentFilterType(&filterTypeEnum)
 	}
 
 	return target

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/model.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/model.go
@@ -9,6 +9,7 @@ import (
 
 type WindowsEnrollmentStatusPageResourceModel struct {
 	ID                                                       types.String `tfsdk:"id"`
+	Priority                                                 types.Int32  `tfsdk:"priority"`
 	DisplayName                                              types.String `tfsdk:"display_name"`
 	Description                                              types.String `tfsdk:"description"`
 	ShowInstallationProgress                                 types.Bool   `tfsdk:"show_installation_progress"`
@@ -20,7 +21,7 @@ type WindowsEnrollmentStatusPageResourceModel struct {
 	AllowDeviceUseOnInstallFailure                           types.Bool   `tfsdk:"allow_device_use_on_install_failure"`
 	BlockDeviceUseUntilAllAppsAndProfilesAreInstalled        types.Bool   `tfsdk:"block_device_use_until_all_apps_and_profiles_are_installed"`
 	SelectedMobileAppIds                                     types.Set    `tfsdk:"selected_mobile_app_ids"`
-	//TrackInstallProgressForAutopilotOnly                     types.Bool     `tfsdk:"track_install_progress_for_autopilot_only"`
+	// TrackInstallProgressForAutopilotOnly                     types.Bool     `tfsdk:"track_install_progress_for_autopilot_only"`
 	OnlyFailSelectedBlockingAppsInTechnicianPhase types.Bool     `tfsdk:"only_fail_selected_blocking_apps_in_technician_phase"`
 	InstallQualityUpdates                         types.Bool     `tfsdk:"install_quality_updates"`
 	RoleScopeTagIds                               types.Set      `tfsdk:"role_scope_tag_ids"`

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource.go
@@ -4,12 +4,6 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/client"
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
-	planmodifiers "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/plan_modifiers"
-	commonschema "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/schema"
-	commonschemagraphbeta "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/schema/graph_beta/device_management"
-	validate "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/validate/attribute"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -23,6 +17,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	msgraphbetasdk "github.com/microsoftgraph/msgraph-beta-sdk-go"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/client"
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
+	planmodifiers "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/plan_modifiers"
+	commonschema "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/schema"
+	commonschemagraphbeta "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/schema/graph_beta/device_management"
+	validate "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/validate/attribute"
 )
 
 const (
@@ -72,20 +73,36 @@ type WindowsEnrollmentStatusPageResource struct {
 	ResourcePath     string
 }
 
-func (r *WindowsEnrollmentStatusPageResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *WindowsEnrollmentStatusPageResource) Metadata(
+	ctx context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = ResourceName
 }
 
-func (r *WindowsEnrollmentStatusPageResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *WindowsEnrollmentStatusPageResource) Configure(
+	ctx context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = client.SetGraphBetaClientForResource(ctx, req, resp, ResourceName)
 }
 
-func (r *WindowsEnrollmentStatusPageResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *WindowsEnrollmentStatusPageResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // IdentitySchema defines the identity schema for this resource, used by list operations to uniquely identify instances
-func (r *WindowsEnrollmentStatusPageResource) IdentitySchema(ctx context.Context, req resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+func (r *WindowsEnrollmentStatusPageResource) IdentitySchema(
+	ctx context.Context,
+	req resource.IdentitySchemaRequest,
+	resp *resource.IdentitySchemaResponse,
+) {
 	resp.IdentitySchema = identityschema.Schema{
 		Attributes: map[string]identityschema.Attribute{
 			"id": identityschema.StringAttribute{
@@ -95,7 +112,11 @@ func (r *WindowsEnrollmentStatusPageResource) IdentitySchema(ctx context.Context
 	}
 }
 
-func (r *WindowsEnrollmentStatusPageResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *WindowsEnrollmentStatusPageResource) Schema(
+	ctx context.Context,
+	req resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a Windows 10 Enrollment Status Page configuration in Microsoft Intune." +
 			" Using the `/deviceManagement/deviceEnrollmentConfigurations/{deviceEnrollmentConfigurationId}` endpoint." +
@@ -109,6 +130,11 @@ func (r *WindowsEnrollmentStatusPageResource) Schema(ctx context.Context, req re
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"priority": schema.Int32Attribute{
+				MarkdownDescription: "Priority is used to break ties when a user or device is targeted by multiple profiles. Lower priority values take precedence.",
+				Optional:            true,
+				Computed:            true,
 			},
 			"display_name": schema.StringAttribute{
 				MarkdownDescription: "The display name of the enrollment status page configuration.",
@@ -223,7 +249,7 @@ func (r *WindowsEnrollmentStatusPageResource) Schema(ctx context.Context, req re
 					),
 				},
 			},
-			"assignments": commonschemagraphbeta.DeviceConfigurationWithAllLicensedUsersAllDevicesInclusionGroupAssignmentsSchema(),
+			"assignments": commonschemagraphbeta.DeviceConfigurationWithAllLicensedUsersAllDevicesInclusionGroupAssignmentsAndFilterSchema(),
 			"timeouts":    commonschema.ResourceTimeouts(ctx),
 		},
 	}

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource_test.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource_test.go
@@ -115,6 +115,7 @@ func TestUnitResourceWindowsEnrollmentStatusPage_02_Maximal(t *testing.T) {
 				Config: loadUnitTestTerraform("resource_maximal.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("id").MatchesRegex(regexp.MustCompile(`^[0-9a-fA-F-]+$`)),
+					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("priority").HasValue("10"),
 					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("display_name").HasValue("unit-test-windows-enrollment-status-page-maximal"),
 					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("description").HasValue("Test description for maximal enrollment status page"),
 					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("show_installation_progress").HasValue("true"),
@@ -129,6 +130,11 @@ func TestUnitResourceWindowsEnrollmentStatusPage_02_Maximal(t *testing.T) {
 					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("custom_error_message").HasValue("Contact IT support for assistance"),
 					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("selected_mobile_app_ids.#").HasValue("3"),
 					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("role_scope_tag_ids.#").HasValue("2"),
+					check.That(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal").Key("assignments.#").HasValue("4"),
+					resource.TestCheckTypeSetElemNestedAttrs(graphBetaWindowsEnrollmentStatusPage.ResourceName+".maximal", "assignments.*", map[string]string{
+						"filter_id":   "33333333-3333-3333-3333-333333333333",
+						"filter_type": "include",
+					}),
 				),
 			},
 		},

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource_test_helper.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource_test_helper.go
@@ -3,18 +3,30 @@ package graphBetaWindowsEnrollmentStatusPage
 import (
 	"context"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/acceptance/exists"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	msgraphbetasdk "github.com/microsoftgraph/msgraph-beta-sdk-go"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/acceptance/exists"
 )
 
 type WindowsEnrollmentStatusPageTestResource struct{}
 
 // Exists checks whether the Windows enrollment status page exists in Microsoft Graph
-func (r WindowsEnrollmentStatusPageTestResource) Exists(ctx context.Context, _ any, state *terraform.InstanceState) (*bool, error) {
+func (r WindowsEnrollmentStatusPageTestResource) Exists(
+	ctx context.Context,
+	_ any,
+	state *terraform.InstanceState,
+) (*bool, error) {
 	//nolint:wrapcheck // Direct pass-through to generic helper with contextual errors
-	return exists.CheckResourceExists(ctx, state, func(client *msgraphbetasdk.GraphServiceClient, ctx context.Context, state *terraform.InstanceState) error {
-		_, err := client.DeviceManagement().DeviceEnrollmentConfigurations().ByDeviceEnrollmentConfigurationId(state.ID).Get(ctx, nil)
-		return err
-	})
+	return exists.CheckResourceExists(
+		ctx,
+		state,
+		func(client *msgraphbetasdk.GraphServiceClient, ctx context.Context, state *terraform.InstanceState) error {
+			_, err := client.DeviceManagement().
+				DeviceEnrollmentConfigurations().
+				ByDeviceEnrollmentConfigurationId(state.ID).
+				Get(ctx, nil)
+			return err
+		},
+	)
 }

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/state.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/state.go
@@ -4,55 +4,93 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	graphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 )
 
 // MapRemoteStateToTerraform maps the remote state to the Terraform state
-func MapRemoteStateToTerraform(ctx context.Context, data *WindowsEnrollmentStatusPageResourceModel, remoteResource graphmodels.DeviceEnrollmentConfigurationable) {
+func MapRemoteStateToTerraform(
+	ctx context.Context,
+	data *WindowsEnrollmentStatusPageResourceModel,
+	remoteResource graphmodels.DeviceEnrollmentConfigurationable,
+) {
 	if remoteResource == nil {
 		tflog.Debug(ctx, "Remote resource is nil")
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Starting to map remote state to Terraform state for %s", ResourceName))
+	tflog.Debug(
+		ctx,
+		fmt.Sprintf("Starting to map remote state to Terraform state for %s", ResourceName),
+	)
 
 	// Cast to the specific type
 	enrollmentConfig, ok := remoteResource.(graphmodels.Windows10EnrollmentCompletionPageConfigurationable)
 	if !ok {
-		tflog.Error(ctx, "Failed to cast remote resource to Windows10EnrollmentCompletionPageConfiguration")
+		tflog.Error(
+			ctx,
+			"Failed to cast remote resource to Windows10EnrollmentCompletionPageConfiguration",
+		)
 		return
 	}
 
 	// Map basic fields using convert helpers
 	data.ID = convert.GraphToFrameworkString(enrollmentConfig.GetId())
+	data.Priority = convert.GraphToFrameworkInt32(enrollmentConfig.GetPriority())
 	data.DisplayName = convert.GraphToFrameworkString(enrollmentConfig.GetDisplayName())
 	data.Description = convert.GraphToFrameworkString(enrollmentConfig.GetDescription())
 
 	// Map installation progress settings
-	data.ShowInstallationProgress = convert.GraphToFrameworkBool(enrollmentConfig.GetShowInstallationProgress())
-	data.BlockDeviceUseUntilAllAppsAndProfilesAreInstalled = convert.GraphToFrameworkBool(enrollmentConfig.GetBlockDeviceSetupRetryByUser())
-	data.AllowDeviceResetOnInstallFailure = convert.GraphToFrameworkBool(enrollmentConfig.GetAllowDeviceResetOnInstallFailure())
-	data.AllowLogCollectionOnInstallFailure = convert.GraphToFrameworkBool(enrollmentConfig.GetAllowLogCollectionOnInstallFailure())
-	data.CustomErrorMessage = convert.GraphToFrameworkString(enrollmentConfig.GetCustomErrorMessage())
-	data.InstallProgressTimeoutInMinutes = convert.GraphToFrameworkInt32(enrollmentConfig.GetInstallProgressTimeoutInMinutes())
-	data.AllowDeviceUseOnInstallFailure = convert.GraphToFrameworkBool(enrollmentConfig.GetAllowDeviceUseOnInstallFailure())
+	data.ShowInstallationProgress = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetShowInstallationProgress(),
+	)
+	data.BlockDeviceUseUntilAllAppsAndProfilesAreInstalled = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetBlockDeviceSetupRetryByUser(),
+	)
+	data.AllowDeviceResetOnInstallFailure = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetAllowDeviceResetOnInstallFailure(),
+	)
+	data.AllowLogCollectionOnInstallFailure = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetAllowLogCollectionOnInstallFailure(),
+	)
+	data.CustomErrorMessage = convert.GraphToFrameworkString(
+		enrollmentConfig.GetCustomErrorMessage(),
+	)
+	data.InstallProgressTimeoutInMinutes = convert.GraphToFrameworkInt32(
+		enrollmentConfig.GetInstallProgressTimeoutInMinutes(),
+	)
+	data.AllowDeviceUseOnInstallFailure = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetAllowDeviceUseOnInstallFailure(),
+	)
 
 	// Map autopilot and user tracking settings
-	//data.TrackInstallProgressForAutopilotOnly = convert.GraphToFrameworkBool(enrollmentConfig.GetTrackInstallProgressForAutopilotOnly())
-	data.OnlyShowPageToDevicesProvisionedByOutOfBoxExperienceOobe = convert.GraphToFrameworkBool(enrollmentConfig.GetDisableUserStatusTrackingAfterFirstUser())
+	// data.TrackInstallProgressForAutopilotOnly = convert.GraphToFrameworkBool(enrollmentConfig.GetTrackInstallProgressForAutopilotOnly())
+	data.OnlyShowPageToDevicesProvisionedByOutOfBoxExperienceOobe = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetDisableUserStatusTrackingAfterFirstUser(),
+	)
 
 	// Map app installation settings
-	data.OnlyFailSelectedBlockingAppsInTechnicianPhase = convert.GraphToFrameworkBool(enrollmentConfig.GetAllowNonBlockingAppInstallation())
-	data.InstallQualityUpdates = convert.GraphToFrameworkBool(enrollmentConfig.GetInstallQualityUpdates())
+	data.OnlyFailSelectedBlockingAppsInTechnicianPhase = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetAllowNonBlockingAppInstallation(),
+	)
+	data.InstallQualityUpdates = convert.GraphToFrameworkBool(
+		enrollmentConfig.GetInstallQualityUpdates(),
+	)
 
 	// Map selected mobile app IDs
-	data.SelectedMobileAppIds = convert.GraphToFrameworkStringSet(ctx, enrollmentConfig.GetSelectedMobileAppIds())
+	data.SelectedMobileAppIds = convert.GraphToFrameworkStringSet(
+		ctx,
+		enrollmentConfig.GetSelectedMobileAppIds(),
+	)
 
 	// Map role scope tag IDs
-	data.RoleScopeTagIds = convert.GraphToFrameworkStringSet(ctx, enrollmentConfig.GetRoleScopeTagIds())
+	data.RoleScopeTagIds = convert.GraphToFrameworkStringSet(
+		ctx,
+		enrollmentConfig.GetRoleScopeTagIds(),
+	)
 
 	assignments := remoteResource.GetAssignments()
 
@@ -65,5 +103,8 @@ func MapRemoteStateToTerraform(ctx context.Context, data *WindowsEnrollmentStatu
 		})
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished stating resource %s with id %s", ResourceName, data.ID.ValueString()))
+	tflog.Debug(
+		ctx,
+		fmt.Sprintf("Finished stating resource %s with id %s", ResourceName, data.ID.ValueString()),
+	)
 }

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/state_assignments.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/state_assignments.go
@@ -3,25 +3,32 @@ package graphBetaWindowsEnrollmentStatusPage
 import (
 	"context"
 
-	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	graphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
+
+	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/convert"
 )
 
 // WindowsEnrollmentStatusPageAssignmentType returns the object type for WindowsQualityUpdateProfileAssignmentModel
 func WindowsEnrollmentStatusPageAssignmentType() attr.Type {
 	return types.ObjectType{
 		AttrTypes: map[string]attr.Type{
-			"type":     types.StringType,
-			"group_id": types.StringType,
+			"type":        types.StringType,
+			"group_id":    types.StringType,
+			"filter_id":   types.StringType,
+			"filter_type": types.StringType,
 		},
 	}
 }
 
 // MapAssignmentsToTerraform maps the remote Windows Quality Update Policy assignments to Terraform state
-func MapAssignmentsToTerraform(ctx context.Context, data *WindowsEnrollmentStatusPageResourceModel, assignments []graphmodels.EnrollmentConfigurationAssignmentable) {
+func MapAssignmentsToTerraform(
+	ctx context.Context,
+	data *WindowsEnrollmentStatusPageResourceModel,
+	assignments []graphmodels.EnrollmentConfigurationAssignmentable,
+) {
 	if len(assignments) == 0 {
 		tflog.Debug(ctx, "No assignments to process")
 		data.Assignments = types.SetNull(WindowsEnrollmentStatusPageAssignmentType())
@@ -54,11 +61,15 @@ func MapAssignmentsToTerraform(ctx context.Context, data *WindowsEnrollmentStatu
 
 		odataType := target.GetOdataType()
 		if odataType == nil {
-			tflog.Warn(ctx, "Assignment target OData type is nil, skipping assignment", map[string]any{
-				"assignmentIndex": i,
-				"assignmentId":    assignment.GetId(),
-				"resourceId":      data.ID.ValueString(),
-			})
+			tflog.Warn(
+				ctx,
+				"Assignment target OData type is nil, skipping assignment",
+				map[string]any{
+					"assignmentIndex": i,
+					"assignmentId":    assignment.GetId(),
+					"resourceId":      data.ID.ValueString(),
+				},
+			)
 			continue
 		}
 
@@ -70,8 +81,10 @@ func MapAssignmentsToTerraform(ctx context.Context, data *WindowsEnrollmentStatu
 		})
 
 		assignmentObj := map[string]attr.Value{
-			"type":     types.StringNull(),
-			"group_id": types.StringNull(),
+			"type":        types.StringNull(),
+			"group_id":    types.StringNull(),
+			"filter_id":   types.StringNull(),
+			"filter_type": types.StringValue("none"),
 		}
 
 		switch *odataType {
@@ -94,19 +107,27 @@ func MapAssignmentsToTerraform(ctx context.Context, data *WindowsEnrollmentStatu
 					})
 					assignmentObj["group_id"] = convert.GraphToFrameworkString(groupId)
 				} else {
-					tflog.Warn(ctx, "Group ID is nil/empty for group assignment target", map[string]any{
-						"assignmentIndex": i,
-						"assignmentId":    assignment.GetId(),
-						"resourceId":      data.ID.ValueString(),
-					})
+					tflog.Warn(
+						ctx,
+						"Group ID is nil/empty for group assignment target",
+						map[string]any{
+							"assignmentIndex": i,
+							"assignmentId":    assignment.GetId(),
+							"resourceId":      data.ID.ValueString(),
+						},
+					)
 					assignmentObj["group_id"] = types.StringNull()
 				}
 			} else {
-				tflog.Error(ctx, "Failed to cast target to GroupAssignmentTargetable", map[string]any{
-					"assignmentIndex": i,
-					"assignmentId":    assignment.GetId(),
-					"resourceId":      data.ID.ValueString(),
-				})
+				tflog.Error(
+					ctx,
+					"Failed to cast target to GroupAssignmentTargetable",
+					map[string]any{
+						"assignmentIndex": i,
+						"assignmentId":    assignment.GetId(),
+						"resourceId":      data.ID.ValueString(),
+					},
+				)
 				assignmentObj["group_id"] = types.StringNull()
 			}
 
@@ -139,13 +160,33 @@ func MapAssignmentsToTerraform(ctx context.Context, data *WindowsEnrollmentStatu
 			continue
 		}
 
+		filterID := target.GetDeviceAndAppManagementAssignmentFilterId()
+		if filterID != nil && *filterID != "" {
+			assignmentObj["filter_id"] = convert.GraphToFrameworkString(filterID)
+		}
+
+		filterType := target.GetDeviceAndAppManagementAssignmentFilterType()
+		if filterType != nil {
+			switch *filterType {
+			case graphmodels.INCLUDE_DEVICEANDAPPMANAGEMENTASSIGNMENTFILTERTYPE:
+				assignmentObj["filter_type"] = types.StringValue("include")
+			case graphmodels.EXCLUDE_DEVICEANDAPPMANAGEMENTASSIGNMENTFILTERTYPE:
+				assignmentObj["filter_type"] = types.StringValue("exclude")
+			case graphmodels.NONE_DEVICEANDAPPMANAGEMENTASSIGNMENTFILTERTYPE:
+				assignmentObj["filter_type"] = types.StringValue("none")
+			}
+		}
+
 		tflog.Debug(ctx, "Creating assignment object value", map[string]any{
 			"assignmentIndex": i,
 			"assignmentId":    assignment.GetId(),
 			"resourceId":      data.ID.ValueString(),
 		})
 
-		objValue, diags := types.ObjectValue(WindowsEnrollmentStatusPageAssignmentType().(types.ObjectType).AttrTypes, assignmentObj)
+		objValue, diags := types.ObjectValue(
+			WindowsEnrollmentStatusPageAssignmentType().(types.ObjectType).AttrTypes,
+			assignmentObj,
+		)
 		if !diags.HasError() {
 			tflog.Debug(ctx, "Successfully created assignment object", map[string]any{
 				"assignmentIndex": i,
@@ -170,7 +211,10 @@ func MapAssignmentsToTerraform(ctx context.Context, data *WindowsEnrollmentStatu
 	})
 
 	if len(assignmentValues) > 0 {
-		setVal, diags := types.SetValue(WindowsEnrollmentStatusPageAssignmentType(), assignmentValues)
+		setVal, diags := types.SetValue(
+			WindowsEnrollmentStatusPageAssignmentType(),
+			assignmentValues,
+		)
 		if diags.HasError() {
 			tflog.Error(ctx, "Failed to create assignments set", map[string]any{
 				"errors":     diags.Errors(),
@@ -185,9 +229,13 @@ func MapAssignmentsToTerraform(ctx context.Context, data *WindowsEnrollmentStatu
 			data.Assignments = setVal
 		}
 	} else {
-		tflog.Debug(ctx, "No valid assignments processed, setting assignments to null", map[string]any{
-			"resourceId": data.ID.ValueString(),
-		})
+		tflog.Debug(
+			ctx,
+			"No valid assignments processed, setting assignments to null",
+			map[string]any{
+				"resourceId": data.ID.ValueString(),
+			},
+		)
 		data.Assignments = types.SetNull(WindowsEnrollmentStatusPageAssignmentType())
 	}
 

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/responses/validate_get/get_windows_enrollment_status_page_with_assignments.json
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/responses/validate_get/get_windows_enrollment_status_page_with_assignments.json
@@ -26,7 +26,9 @@
       "id": "assignment1",
       "target": {
         "@odata.type": "#microsoft.graph.groupAssignmentTarget",
-        "groupId": "12345678-1234-1234-1234-123456789012"
+        "groupId": "12345678-1234-1234-1234-123456789012",
+        "deviceAndAppManagementAssignmentFilterId": "33333333-3333-3333-3333-333333333333",
+        "deviceAndAppManagementAssignmentFilterType": "include"
       }
     },
     {

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/terraform/unit/resource_maximal.tf
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/terraform/unit/resource_maximal.tf
@@ -1,4 +1,5 @@
 resource "microsoft365_graph_beta_device_management_windows_enrollment_status_page" "maximal" {
+  priority                                                            = 10
   display_name                                                        = "unit-test-windows-enrollment-status-page-maximal"
   description                                                         = "Test description for maximal enrollment status page"
   show_installation_progress                                          = true
@@ -8,10 +9,9 @@ resource "microsoft365_graph_beta_device_management_windows_enrollment_status_pa
   allow_log_collection_on_install_failure                             = true
   only_show_page_to_devices_provisioned_by_out_of_box_experience_oobe = true
 
-  block_device_use_until_all_apps_and_profiles_are_installed = false // this set to false enables the fields below to work
-  allow_device_reset_on_install_failure                      = true  // can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false
-  allow_device_use_on_install_failure                        = true  // can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false
-
+  block_device_use_until_all_apps_and_profiles_are_installed = false
+  allow_device_reset_on_install_failure                      = true
+  allow_device_use_on_install_failure                        = true
 
   selected_mobile_app_ids = [ // if not set, this sets the field to 'all' in the gui. // can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false
     "e4938228-aab3-493b-a9d5-8250aa8e9d55",
@@ -22,6 +22,25 @@ resource "microsoft365_graph_beta_device_management_windows_enrollment_status_pa
   only_fail_selected_blocking_apps_in_technician_phase = true // can only be set to true if block_device_use_until_all_apps_and_profiles_are_installed is false and selected_mobile_app_ids is set
 
   role_scope_tag_ids = ["0", "1"]
+
+  assignments = [
+    {
+      type = "allDevicesAssignmentTarget"
+    },
+    {
+      type = "allLicensedUsersAssignmentTarget"
+    },
+    {
+      type     = "groupAssignmentTarget"
+      group_id = "11111111-1111-1111-1111-111111111111"
+    },
+    {
+      type        = "groupAssignmentTarget"
+      group_id    = "22222222-2222-2222-2222-222222222222"
+      filter_id   = "33333333-3333-3333-3333-333333333333"
+      filter_type = "include"
+    }
+  ]
 
   timeouts = {
     create = "30s"


### PR DESCRIPTION
# Pull Request Description

## Summary

Adds two previously unsupported Microsoft Graph capabilities to `microsoft365_graph_beta_device_management_windows_enrollment_status_page`:

1. `priority` (optional, computed `int32`) — maps to Graph's `windows10EnrollmentCompletionPageConfiguration.priority`, used to break ties when a device/user is targeted by multiple enrollment status page profiles.
2. Assignment filters (`filter_id` / `filter_type`) on the `assignments` block — maps to Graph's `deviceAndAppManagementAssignmentFilterId` / `deviceAndAppManagementAssignmentFilterType` on `allDevicesAssignmentTarget`, `allLicensedUsersAssignmentTarget`, and `groupAssignmentTarget`.

Both are optional/backward compatible.

### Issue Reference

N/A

### Motivation and Context

- Previously, `priority` and assignment filters had to be set manually in the Intune portal after every `terraform apply`, since the resource never read or wrote them, causing perpetual drift or silent loss of that configuration on refresh.
- This closes that gap by exposing both as first-class, optional attributes, following the same `filter_id`/`filter_type` naming and validation conventions already used by sibling resources (e.g. Windows Autopilot Device Preparation Policy, Windows Remediation Script).

### Dependencies

- No new external dependencies.
- No configuration changes required for existing users; attributes are optional and only take effect when set.

## Type of Change

Please mark the relevant option with an `x`:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: 

Notes:
- Extended `resource_maximal.tf` and its mocked Graph responses to cover `priority` and a filtered `groupAssignmentTarget` assignment.
- Ran the full focused unit suite locally: `go test ./internal/services/resources/device_management/graph_beta/windows_enrollment_status_page -run '^TestUnitResourceWindowsEnrollmentStatusPage' -count=1 -v` — all 6 tests pass.
- Ran the golangci-lint
- Acceptance tests (`TF_ACC=1`) were not run against a live tenant as part of this change; recommend running before merge if a test tenant is available, to confirm the filtered assignment and priority-only update round-trip without drift.

Test results
```
=== RUN   TestUnitResourceWindowsEnrollmentStatusPage_01_Minimal
--- PASS: TestUnitResourceWindowsEnrollmentStatusPage_01_Minimal (10.71s)
=== RUN   TestUnitResourceWindowsEnrollmentStatusPage_02_Maximal
--- PASS: TestUnitResourceWindowsEnrollmentStatusPage_02_Maximal (10.37s)
=== RUN   TestUnitResourceWindowsEnrollmentStatusPage_03_WithAssignments
--- PASS: TestUnitResourceWindowsEnrollmentStatusPage_03_WithAssignments (11.00s)
=== RUN   TestUnitResourceWindowsEnrollmentStatusPage_04_ErrorHandling
--- PASS: TestUnitResourceWindowsEnrollmentStatusPage_04_ErrorHandling (7.75s)
=== RUN   TestUnitResourceWindowsEnrollmentStatusPage_05_Lifecycle_MinimalToMaximal
--- PASS: TestUnitResourceWindowsEnrollmentStatusPage_05_Lifecycle_MinimalToMaximal (14.31s)
=== RUN   TestUnitResourceWindowsEnrollmentStatusPage_06_Lifecycle_MaximalToMinimal
--- PASS: TestUnitResourceWindowsEnrollmentStatusPage_06_Lifecycle_MaximalToMinimal (14.99s)
PASS
```

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

N/A

## Additional Notes

- Filter support is intentionally scoped to `allDevicesAssignmentTarget`, `allLicensedUsersAssignmentTarget`, and `groupAssignmentTarget` only, matching what the Intune portal actually allows for this resource type; `exclusionGroupAssignmentTarget` was deliberately not added to follow the structure.
- A new shared schema helper, `DeviceConfigurationWithAllLicensedUsersAllDevicesInclusionGroupAssignmentsAndFilterSchema`, was added to `device_configuration_assignment.go` for reuse by other resources needing this exact target/filter combination.
- Diff is intentionally scoped to this resource only; no other resource's schema was changed.
