### PR TITLE
fix: retain device security group on autopilot device preparation policy update

### DIFF
--- a/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/crud.go
+++ b/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/crud.go
@@ -426,6 +426,11 @@ func (r *WindowsAutopilotDevicePreparationPolicyResource) Update(
 		}
 	}
 
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	readReq := resource.ReadRequest{State: resp.State, ProviderMeta: req.ProviderMeta}
 	stateContainer := &crud.UpdateResponseContainer{UpdateResponse: resp}
 

--- a/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/mocks/responders.go
+++ b/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/mocks/responders.go
@@ -333,10 +333,10 @@ func (m *WindowsAutopilotDevicePreparationPolicyMock) RegisterMocks() {
 	// on the 'settings' navigation property of deviceManagementConfigurationPolicy.
 	httpmock.RegisterResponder(
 		"PUT",
-		`=~^https://graph\.microsoft\.com/beta/deviceManagement/configurationPolicies/[0-9a-fA-F-]+$`,
+		`=~^https://graph\.microsoft\.com/beta/deviceManagement/configurationPolicies\('[0-9a-fA-F-]+'\)$`,
 		func(req *http.Request) (*http.Response, error) {
 			parts := strings.Split(req.URL.Path, "/")
-			id := parts[len(parts)-1]
+			id := strings.TrimSuffix(strings.TrimPrefix(parts[len(parts)-1], "configurationPolicies('"), "')")
 
 			var body map[string]any
 			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {

--- a/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/resource_test.go
+++ b/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/resource_test.go
@@ -224,6 +224,33 @@ func TestUnitResourceWindowsAutopilotDevicePreparationPolicy_08_AutomaticWithout
 	}
 }
 
+// Test 09: Automatic mode update preserves the enrollment-time device group in state.
+func TestUnitResourceWindowsAutopilotDevicePreparationPolicy_09_AutomaticUpdatePreservesDeviceSecurityGroup(t *testing.T) {
+	mocks.SetupUnitTestEnvironment(t)
+	_, policyMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer policyMock.CleanupMockState()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: loadUnitTestTerraform("001_scenario_automatic_minimal.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".auto_minimal").Key("device_security_group").HasValue("00000000-0000-0000-0000-000000000001"),
+				),
+			},
+			{
+				Config: loadUnitTestTerraform("008_scenario_automatic_update.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					check.That(resourceType+".auto_minimal").Key("description").HasValue("Unit test for automatic mode update"),
+					check.That(resourceType+".auto_minimal").Key("device_security_group").HasValue("00000000-0000-0000-0000-000000000001"),
+				),
+			},
+		},
+	})
+}
+
 // Test 07: Error handling - API rejection
 func TestUnitResourceWindowsAutopilotDevicePreparationPolicy_07_ErrorHandling(t *testing.T) {
 	mocks.SetupUnitTestEnvironment(t)

--- a/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/tests/terraform/unit/008_scenario_automatic_update.tf
+++ b/internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy/tests/terraform/unit/008_scenario_automatic_update.tf
@@ -1,0 +1,18 @@
+resource "microsoft365_graph_beta_device_management_windows_autopilot_device_preparation_policy" "auto_minimal" {
+  name               = "unit-test-autopilot-dpp-auto-minimal"
+  description        = "Unit test for automatic mode update"
+  role_scope_tag_ids = ["0"]
+
+  deployment_settings = {
+    deployment_type = "enrollment_autopilot_dpp_deploymenttype_1"
+  }
+
+  device_security_group = "00000000-0000-0000-0000-000000000001"
+
+  allowed_apps = [
+    {
+      app_id   = "00000000-0000-0000-0000-000000000001"
+      app_type = "winGetApp"
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Fixes an inconsistent Terraform state result when updating a ```windows_autopilot_device_preparation_policy``` with `device_security_group` configured.

### Issue Reference

N/A

### Motivation and Context

- The group assignment succeeds in Intune, but Graph does not return the enrollment-time device membership target during the post-update policy read.
- The provider previously read `device_security_group` as `null`, causing Terraform to fail with `Provider produced inconsistent result after apply`.
- The update response state is now initialized from the Terraform plan before read-back, preserving the configured group when Graph omits that value.
- Adds regression coverage for updating an automatic policy with a device security group.

### Dependencies

- None.
- No configuration, version, or dependency changes.

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: ```go test``` ```go build```

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [ ] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

N/A

## Additional Notes

Validation performed locally:

```go test ./internal/services/resources/device_management/graph_beta/windows_autopilot_device_preparation_policy -run '^TestUnitResourceWindowsAutopilotDevicePreparationPolicy' -count=1```

```go build ./...```

Both passing as expected.