### PR TITLE
test: correct UnknownError delete retry expectation

### DIFF
--- a/internal/services/common/errors/kiota/retryable_test.go
+++ b/internal/services/common/errors/kiota/retryable_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsRetryableDeleteError(t *testing.T) {
+func TestUnitIsRetryableDeleteError(t *testing.T) {
 	tests := []struct {
 		name           string
 		errorInfo      *GraphErrorInfo
@@ -141,12 +141,20 @@ func TestIsRetryableDeleteError(t *testing.T) {
 			},
 			expectedResult: true,
 		},
-		// Test unknown errors
 		{
-			name: "Unknown status code and error code - should not retry",
+			name: "UnknownError error code - should retry",
 			errorInfo: &GraphErrorInfo{
 				StatusCode: 999,
 				ErrorCode:  "UnknownError",
+			},
+			expectedResult: true,
+		},
+		// Test unrecognized errors
+		{
+			name: "Unrecognized status code and error code - should not retry",
+			errorInfo: &GraphErrorInfo{
+				StatusCode: 999,
+				ErrorCode:  "UnrecognizedErrorCode",
 			},
 			expectedResult: false,
 		},


### PR DESCRIPTION
## Summary

Fix the stale delete-retry test expectation for `UnknownError`. Add an explicit retryable case for that supported Graph error code and use `UnrecognizedErrorCode` for the non-retryable fallback case. Rename the test with the `TestUnit` prefix so `make unittest` includes it.

### Issue Reference

Existing failure found while validating #3778.

### Motivation and Context

Commit 8485beaea added `UnknownError` to the retryable delete error codes, but the test still expected it to be non-retryable. This corrects the test without changing runtime behavior.

### Dependencies

None. This PR is based directly on main and is independent of #3778.

## Type of Change

- [x] 🐛 Bug fix (test expectation)

## Testing

- Reproduced the existing failure on main at b813d935b.
- `go test ./internal/services/common/errors/kiota -count=1` — passed, with no skipped tests.
- `go test ./internal/services/common/errors/kiota -run '^TestUnitIsRetryableDeleteError$' -count=1 -v` — all 20 cases passed.
- `golangci-lint run ./internal/services/common/errors/kiota/...` — 0 issues; existing unused exclusion-rule warnings.
- `git diff --check` — passed.

Validation was scoped to the affected package; the repository-wide suite was not run.

## Quality Checklist

- [x] Reviewed the change and checked for an existing PR covering this fix.
- [x] Changes follow the existing table-driven test style.
- [x] No production code, dependencies, or documentation changes.
