### PR TITLE
fix: windows_enrollment_status_page validate selected_mobile_app_ids by direct lookup instead of paginated list

### DIFF
--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/mocks/responders.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/mocks/responders.go
@@ -17,6 +17,67 @@ var mockState struct {
 	enrollmentStatusPages map[string]map[string]any
 }
 
+// Apps referenced by selected_mobile_app_ids in the unit test configurations.
+var mockMobileApps = map[string]map[string]any{
+	"12345678-1234-1234-1234-123456789012": {
+		"@odata.type":     "#microsoft.graph.win32LobApp",
+		"id":              "12345678-1234-1234-1234-123456789012",
+		"displayName":     "Test App 1",
+		"description":     "Test application 1 for unit testing",
+		"publisher":       "Test Publisher",
+		"publishingState": "published",
+	},
+	"87654321-4321-4321-4321-210987654321": {
+		"@odata.type":     "#microsoft.graph.winGetApp",
+		"id":              "87654321-4321-4321-4321-210987654321",
+		"displayName":     "Test App 2",
+		"description":     "Test application 2 for unit testing",
+		"publisher":       "Test Publisher",
+		"publishingState": "published",
+	},
+	"e4938228-aab3-493b-a9d5-8250aa8e9d55": {
+		"@odata.type":     "#microsoft.graph.win32LobApp",
+		"id":              "e4938228-aab3-493b-a9d5-8250aa8e9d55",
+		"displayName":     "Test App 3",
+		"description":     "Test application 3 for unit testing",
+		"publisher":       "Test Publisher",
+		"publishingState": "published",
+	},
+	"e83d36e1-3ff2-4567-90d9-940919184ad5": {
+		"@odata.type":     "#microsoft.graph.win32LobApp",
+		"id":              "e83d36e1-3ff2-4567-90d9-940919184ad5",
+		"displayName":     "Test App 4",
+		"description":     "Test application 4 for unit testing",
+		"publisher":       "Test Publisher",
+		"publishingState": "published",
+	},
+	"cd4486df-05cc-42bd-8c34-67ac20e10166": {
+		"@odata.type":     "#microsoft.graph.win32LobApp",
+		"id":              "cd4486df-05cc-42bd-8c34-67ac20e10166",
+		"displayName":     "Test App 5",
+		"description":     "Test application 5 for unit testing",
+		"publisher":       "Test Publisher",
+		"publishingState": "published",
+	},
+	"a1b2c3d4-0000-0000-0000-000000000001": {
+		"@odata.type":     "#microsoft.graph.iosStoreApp",
+		"id":              "a1b2c3d4-0000-0000-0000-000000000001",
+		"displayName":     "Test iOS App",
+		"description":     "Non-Windows application for unit testing",
+		"publisher":       "Test Publisher",
+		"publishingState": "published",
+	},
+}
+
+// Deliberately truncated: the list endpoint must never be sufficient to validate
+// selected_mobile_app_ids, so list-based validation regressions fail the tests.
+func mockMobileAppList() []any {
+	return []any{
+		mockMobileApps["12345678-1234-1234-1234-123456789012"],
+		mockMobileApps["87654321-4321-4321-4321-210987654321"],
+	}
+}
+
 func init() {
 	mockState.enrollmentStatusPages = make(map[string]map[string]any)
 	httpmock.RegisterNoResponder(httpmock.NewStringResponder(404, `{"error":{"code":"ResourceNotFound","message":"Resource not found"}}`))
@@ -33,55 +94,27 @@ func (m *WindowsEnrollmentStatusPageMock) RegisterMocks() {
 	mockState.Unlock()
 
 	// Mock the mobile apps endpoint for validation
-	httpmock.RegisterResponder("GET", `=~^https://graph\.microsoft\.com/beta/deviceAppManagement/mobileApps.*`, func(req *http.Request) (*http.Response, error) {
+	httpmock.RegisterResponder("GET", `=~^https://graph\.microsoft\.com/beta/deviceAppManagement/mobileApps(\?.*)?$`, func(req *http.Request) (*http.Response, error) {
 		// Return mock mobile apps that include the test app IDs used in unit tests
 		mockApps := map[string]any{
-			"@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceAppManagement/mobileApps",
-			"@odata.count":   5,
-			"value": []any{
-				map[string]any{
-					"@odata.type":     "#microsoft.graph.win32LobApp",
-					"id":              "12345678-1234-1234-1234-123456789012",
-					"displayName":     "Test App 1",
-					"description":     "Test application 1 for unit testing",
-					"publisher":       "Test Publisher",
-					"publishingState": "published",
-				},
-				map[string]any{
-					"@odata.type":     "#microsoft.graph.winGetApp",
-					"id":              "87654321-4321-4321-4321-210987654321",
-					"displayName":     "Test App 2",
-					"description":     "Test application 2 for unit testing",
-					"publisher":       "Test Publisher",
-					"publishingState": "published",
-				},
-				map[string]any{
-					"@odata.type":     "#microsoft.graph.win32LobApp",
-					"id":              "e4938228-aab3-493b-a9d5-8250aa8e9d55",
-					"displayName":     "Test App 3",
-					"description":     "Test application 3 for unit testing",
-					"publisher":       "Test Publisher",
-					"publishingState": "published",
-				},
-				map[string]any{
-					"@odata.type":     "#microsoft.graph.win32LobApp",
-					"id":              "e83d36e1-3ff2-4567-90d9-940919184ad5",
-					"displayName":     "Test App 4",
-					"description":     "Test application 4 for unit testing",
-					"publisher":       "Test Publisher",
-					"publishingState": "published",
-				},
-				map[string]any{
-					"@odata.type":     "#microsoft.graph.win32LobApp",
-					"id":              "cd4486df-05cc-42bd-8c34-67ac20e10166",
-					"displayName":     "Test App 5",
-					"description":     "Test application 5 for unit testing",
-					"publisher":       "Test Publisher",
-					"publishingState": "published",
-				},
-			},
+			"@odata.context":  "https://graph.microsoft.com/beta/$metadata#deviceAppManagement/mobileApps",
+			"@odata.count":    len(mockMobileApps),
+			"@odata.nextLink": "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps?$skiptoken=page2",
+			"value":           mockMobileAppList(),
 		}
 		return httpmock.NewJsonResponse(200, mockApps)
+	})
+
+	// Mock the single mobile app endpoint used to validate selected_mobile_app_ids
+	httpmock.RegisterResponder("GET", `=~^https://graph\.microsoft\.com/beta/deviceAppManagement/mobileApps/([^/?]+)(\?.*)?$`, func(req *http.Request) (*http.Response, error) {
+		appId := httpmock.MustGetSubmatch(req, 1)
+		app, ok := mockMobileApps[appId]
+		if !ok {
+			return httpmock.NewJsonResponse(404, map[string]any{
+				"error": map[string]any{"code": "ResourceNotFound", "message": "Mobile app not found"},
+			})
+		}
+		return httpmock.NewJsonResponse(200, app)
 	})
 
 	httpmock.RegisterResponder("GET", "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations", func(req *http.Request) (*http.Response, error) {

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource_test.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/resource_test.go
@@ -287,3 +287,39 @@ func TestUnitResourceWindowsEnrollmentStatusPage_06_Lifecycle_MaximalToMinimal(t
 		},
 	})
 }
+
+// Test 007: Selected mobile app of an unsupported platform is rejected
+func TestUnitResourceWindowsEnrollmentStatusPage_07_SelectedMobileAppInvalidType(t *testing.T) {
+	mocks.SetupUnitTestEnvironment(t)
+	_, espMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer espMock.CleanupMockState()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      loadUnitTestTerraform("resource_invalid_app_type.tf"),
+				ExpectError: regexp.MustCompile(`(?s)not\s+a\s+valid\s+Windows\s+app\s+type`),
+			},
+		},
+	})
+}
+
+// Test 008: Selected mobile app that does not exist is rejected
+func TestUnitResourceWindowsEnrollmentStatusPage_08_SelectedMobileAppNotFound(t *testing.T) {
+	mocks.SetupUnitTestEnvironment(t)
+	_, espMock := setupMockEnvironment()
+	defer httpmock.DeactivateAndReset()
+	defer espMock.CleanupMockState()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      loadUnitTestTerraform("resource_unknown_app_id.tf"),
+				ExpectError: regexp.MustCompile(`(?s)not\s+found\s+in\s+Intune`),
+			},
+		},
+	})
+}

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/terraform/unit/resource_invalid_app_type.tf
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/terraform/unit/resource_invalid_app_type.tf
@@ -1,0 +1,30 @@
+resource "microsoft365_graph_beta_device_management_windows_enrollment_status_page" "invalid_app_type" {
+  display_name                                                        = "unit-test-windows-enrollment-status-page-invalid-app-type"
+  description                                                         = "Test description for invalid app type enrollment status page"
+  show_installation_progress                                          = true
+  custom_error_message                                                = "Contact IT support for assistance"
+  install_quality_updates                                             = true
+  install_progress_timeout_in_minutes                                 = 120
+  allow_log_collection_on_install_failure                             = true
+  only_show_page_to_devices_provisioned_by_out_of_box_experience_oobe = true
+
+  block_device_use_until_all_apps_and_profiles_are_installed = false
+  allow_device_reset_on_install_failure                      = true
+  allow_device_use_on_install_failure                        = true
+
+  # iosStoreApp, which is not a supported Windows app type
+  selected_mobile_app_ids = [
+    "a1b2c3d4-0000-0000-0000-000000000001",
+  ]
+
+  only_fail_selected_blocking_apps_in_technician_phase = true
+
+  role_scope_tag_ids = ["0"]
+
+  timeouts = {
+    create = "30s"
+    read   = "30s"
+    update = "30s"
+    delete = "30s"
+  }
+}

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/terraform/unit/resource_unknown_app_id.tf
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/tests/terraform/unit/resource_unknown_app_id.tf
@@ -1,0 +1,30 @@
+resource "microsoft365_graph_beta_device_management_windows_enrollment_status_page" "unknown_app_id" {
+  display_name                                                        = "unit-test-windows-enrollment-status-page-unknown-app-id"
+  description                                                         = "Test description for unknown app id enrollment status page"
+  show_installation_progress                                          = true
+  custom_error_message                                                = "Contact IT support for assistance"
+  install_quality_updates                                             = true
+  install_progress_timeout_in_minutes                                 = 120
+  allow_log_collection_on_install_failure                             = true
+  only_show_page_to_devices_provisioned_by_out_of_box_experience_oobe = true
+
+  block_device_use_until_all_apps_and_profiles_are_installed = false
+  allow_device_reset_on_install_failure                      = true
+  allow_device_use_on_install_failure                        = true
+
+  # Not present in the tenant
+  selected_mobile_app_ids = [
+    "99999999-9999-9999-9999-999999999999",
+  ]
+
+  only_fail_selected_blocking_apps_in_technician_phase = true
+
+  role_scope_tag_ids = ["0"]
+
+  timeouts = {
+    create = "30s"
+    read   = "30s"
+    update = "30s"
+    delete = "30s"
+  }
+}

--- a/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/validate.go
+++ b/internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/validate.go
@@ -3,14 +3,35 @@ package graphBetaWindowsEnrollmentStatusPage
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/deploymenttheory/terraform-provider-microsoft365/internal/constants"
+	errors "github.com/deploymenttheory/terraform-provider-microsoft365/internal/services/common/errors/kiota"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	msgraphbetasdk "github.com/microsoftgraph/msgraph-beta-sdk-go"
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/deviceappmanagement"
 )
+
+var validWindowsAppTypeNames = []string{
+	"windowsAppX",
+	"windowsMobileMSI",
+	"windowsUniversalAppX",
+	"officeSuiteApp",
+	"windowsMicrosoftEdgeApp",
+	"winGetApp",
+	"win32LobApp",
+	"win32CatalogApp",
+}
+
+var validWindowsAppTypes = func() map[string]bool {
+	m := make(map[string]bool, len(validWindowsAppTypeNames))
+	for _, t := range validWindowsAppTypeNames {
+		m[t] = true
+	}
+	return m
+}()
 
 // validateRequest validates the entire request payload
 func validateRequest(ctx context.Context, client *msgraphbetasdk.GraphServiceClient, data *WindowsEnrollmentStatusPageResourceModel) error {
@@ -48,60 +69,50 @@ func validateSelectedMobileAppIds(ctx context.Context, client *msgraphbetasdk.Gr
 		return nil
 	}
 
-	// Get all Windows app types from Microsoft Graph
-	filter := "isof('microsoft.graph.windowsAppX') or isof('microsoft.graph.windowsMobileMSI') or isof('microsoft.graph.windowsUniversalAppX') or isof('microsoft.graph.officeSuiteApp') or isof('microsoft.graph.windowsMicrosoftEdgeApp') or isof('microsoft.graph.winGetApp') or isof('microsoft.graph.win32LobApp') or isof('microsoft.graph.win32CatalogApp')"
-	orderby := "displayname"
-	top := int32(250)
-
-	requestConfig := &deviceappmanagement.MobileAppsRequestBuilderGetRequestConfiguration{
-		QueryParameters: &deviceappmanagement.MobileAppsRequestBuilderGetQueryParameters{
-			Filter:  &filter,
-			Orderby: []string{orderby},
-			Top:     &top,
-		},
-	}
-
-	mobileApps, err := client.
-		DeviceAppManagement().
-		MobileApps().
-		Get(ctx, requestConfig)
-
-	if err != nil {
-		tflog.Error(ctx, "Failed to retrieve mobile apps for validation", map[string]any{
-			"error": err.Error(),
-		})
-		return fmt.Errorf("failed to validate mobile app IDs: unable to retrieve available apps from Microsoft Graph")
-	}
-
-	// Create a map of valid app IDs for quick lookup
-	validAppIds := make(map[string]string)   // ID -> DisplayName
-	validAppTypes := make(map[string]string) // ID -> AppType
-
-	if mobileApps.GetValue() != nil {
-		for _, app := range mobileApps.GetValue() {
-			if app.GetId() != nil && app.GetDisplayName() != nil && app.GetOdataType() != nil {
-				validAppIds[*app.GetId()] = *app.GetDisplayName()
-				validAppTypes[*app.GetId()] = *app.GetOdataType()
-			}
-		}
-	}
-
-	// Validate each provided app ID
+	// Each app is fetched by ID rather than matched against a listing, as any listing is
+	// page limited and would spuriously reject apps in tenants with large app catalogs.
 	for _, appId := range appIdStrings {
 		appIdValue := appId.ValueString()
-		displayName, exists := validAppIds[appIdValue]
 
-		if !exists {
-			return fmt.Errorf("supplied app ID '%s' does not match any valid Windows app types. Valid app types include: windowsAppX, windowsMobileMSI, windowsUniversalAppX, officeSuiteApp, windowsMicrosoftEdgeApp, winGetApp, win32LobApp, win32CatalogApp", appIdValue)
+		app, err := client.
+			DeviceAppManagement().
+			MobileApps().
+			ByMobileAppId(appIdValue).
+			Get(ctx, nil)
+
+		if err != nil {
+			if graphErr := errors.GraphError(ctx, err); graphErr.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("supplied app ID '%s' was not found in Intune", appIdValue)
+			}
+
+			tflog.Error(ctx, "Failed to retrieve mobile app for validation", map[string]any{
+				"appId": appIdValue,
+				"error": err.Error(),
+			})
+			return fmt.Errorf("failed to validate mobile app ID '%s': unable to retrieve app from Microsoft Graph", appIdValue)
+		}
+
+		if app == nil || app.GetOdataType() == nil {
+			return fmt.Errorf("supplied app ID '%s' returned no app type from Microsoft Graph", appIdValue)
+		}
+
+		appType := strings.TrimPrefix(*app.GetOdataType(), "#microsoft.graph.")
+		if !validWindowsAppTypes[appType] {
+			return fmt.Errorf("supplied app ID '%s' is of type '%s' which is not a valid Windows app type. Valid app types include: %s", appIdValue, appType, strings.Join(validWindowsAppTypeNames, ", "))
+		}
+
+		displayName := ""
+		if app.GetDisplayName() != nil {
+			displayName = *app.GetDisplayName()
 		}
 
 		tflog.Debug(ctx, "Validated mobile app", map[string]any{
 			"appId":       appIdValue,
 			"displayName": displayName,
-			"appType":     validAppTypes[appIdValue],
+			"appType":     appType,
 		})
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Validated %d mobile app IDs against %d available Windows apps", len(appIdStrings), len(validAppIds)))
+	tflog.Debug(ctx, fmt.Sprintf("Validated %d mobile app IDs", len(appIdStrings)))
 	return nil
 }


### PR DESCRIPTION
# Pull Request Description

## Summary

Fixes `microsoft365_graph_beta_device_management_windows_enrollment_status_page` incorrectly rejecting valid `selected_mobile_app_ids` in tenants with large Intune app catalogs. Validation now looks up each supplied app ID directly via `ByMobileAppId()` instead of matching against a single, unpaginated `$top=250` listing of the tenant's Windows apps.

### Issue Reference

N/A

### Motivation and Context

- The resource's `validateSelectedMobileAppIds` fetched Windows-type mobile apps with `$filter=isof(...)&$orderby=displayName&$top=250` and only ever requested a single page. It then rejected any supplied app ID not present in that first page.
- In tenants with more than 250 qualifying Windows apps, valid app IDs that sort past the 250th `displayName` are absent from the page, producing:
  `Could not construct resource: ... validation failed: supplied app ID '<guid>' does not match any valid Windows app types.`
  even though the app exists and is a supported type.
- This blocked applies in our production tenant (which has >250 Windows apps) while working fine in test (which does not), since the failure is purely a function of catalog size and display-name sort order.
- Root cause and fix confirmed by reproducing the same `$filter`/`$top=250` Graph query manually against the affected tenant and observing the app ID missing from the returned page.

### Dependencies

- None. No new external dependencies; uses the existing Graph SDK client already present in the package.
- No provider configuration changes required for consumers.

## Type of Change

Please mark the relevant option with an `x`:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this code in the following browsers/environments:

Notes:
- Updated the mock mobile-apps list responder ([mocks/responders.go](internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/mocks/responders.go)) to return only a truncated subset of apps plus an `@odata.nextLink`, and a single-app responder for `ByMobileAppId`. This means existing tests that reference apps outside the truncated page (`02_Maximal`, `03_WithAssignments`, `05_Lifecycle_MinimalToMaximal`, `06_Lifecycle_MaximalToMinimal`) now fail against the old list-based validation and pass against the fix, acting as a regression guard.
- Added `TestUnitResourceWindowsEnrollmentStatusPage_07_SelectedMobileAppInvalidType` — asserts a non-Windows app type (`iosStoreApp`) is rejected with a clear "not a valid Windows app type" error.
- Added `TestUnitResourceWindowsEnrollmentStatusPage_08_SelectedMobileAppNotFound` — asserts a nonexistent app ID is rejected with a "not found in Intune" error (404 path).
- Ran locally: `go build ./...`, `go vet ./internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/...`, and `go test ./internal/services/resources/device_management/graph_beta/windows_enrollment_status_page/... -run "TestUnit" -v -count=1` — all 8 unit tests pass.

## Quality Checklist

- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] I have added necessary documentation (if appropriate)
- [x] I have commented my code, particularly in complex areas
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code is properly formatted according to project standards

## Screenshots/Recordings (if appropriate)

N/A

## Additional Notes

- Error messages are now more specific: "app not found in Intune" vs. "app is of type X which is not a valid Windows app type", instead of a single ambiguous "does not match any valid Windows app types" for all failure modes.
- Per-ID lookups scale with the number of configured `selected_mobile_app_ids` (schema-capped at 100), not with the size of the tenant's app catalog, so this also avoids re-fetching the entire app listing on every plan/apply.
- Worth a follow-up audit: other resources/data sources in this provider that list-and-match against Graph collections with a fixed `$top` and no pagination may have the same class of bug in large tenants.